### PR TITLE
Support Tasty tests

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cabal install --lib QuickCheck
+        cabal install --lib QuickCheck tasty tasty-hunit
         cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all

--- a/Endemic.cabal
+++ b/Endemic.cabal
@@ -94,11 +94,7 @@ test-suite test
                  tasty-expected-failure >= 0.12,
                  containers >= 0.6 && < 0.7,
                  ghc >= 8 && < 9,
-                 hpc >= 0.6 && < 0.7,
                  data-default >= 0.7 && < 0.8,
-                 aeson >= 1.5 && < 1.6,
-                 deriving-aeson >= 0.2 && < 0.3,
-                 bytestring >= 0.10 && < 0.11,
                  Endemic,
                  -- packages used in repair:
                  QuickCheck
@@ -116,12 +112,6 @@ test-suite slow-test
                  tasty-expected-failure >= 0.12,
                  containers >= 0.6 && < 0.7,
                  ghc >= 8 && < 9,
-                 hpc >= 0.6 && < 0.7,
-                 vector >= 0.12 && < 0.13,
-                 data-default >= 0.7 && < 0.8,
-                 aeson >= 1.5 && < 1.6,
-                 deriving-aeson >= 0.2 && < 0.3,
-                 bytestring >= 0.10 && < 0.11,
                  Endemic,
                  -- packages used in repair:
                  QuickCheck

--- a/Endemic.cabal
+++ b/Endemic.cabal
@@ -94,6 +94,7 @@ test-suite test
                  tasty-expected-failure >= 0.12,
                  containers >= 0.6 && < 0.7,
                  ghc >= 8 && < 9,
+                 hpc >= 0.6 && < 0.7,
                  data-default >= 0.7 && < 0.8,
                  Endemic,
                  -- packages used in repair:
@@ -112,6 +113,8 @@ test-suite slow-test
                  tasty-expected-failure >= 0.12,
                  containers >= 0.6 && < 0.7,
                  ghc >= 8 && < 9,
+                 hpc >= 0.6 && < 0.7,
+                 data-default >= 0.7 && < 0.8,
                  Endemic,
                  -- packages used in repair:
                  QuickCheck

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ is defined in `shell.nix`, and can be activated using `nix-shell`, if installed.
 
 **MacOS** users have to use `cabal configure --enable-optimization --enable-executable-dynamic`. Windows users might find some help [here](https://www.linux.org/pages/download/).
 
-To run the program, ensure that `QuickCheck` is installed by running
-`$ cabal install --lib QuickCheck `. You can then run 
+To run the program, ensure that `QuickCheck` and `tasty` are installed by running
+`$ cabal install --lib QuickCheck tasty `. You can then run
 
 ```
 $ cabal run endemic -- examples/BrokenModule.hs
@@ -145,8 +145,8 @@ Usage
 ```
 endemic - Genetic program repair for Haskell
 
-Usage: endemic [--log-loc] [--no-log-timestamp] [--log-level LOGLEVEL] 
-               [--log-file FILE] [--seed INT] [--config CONFIG] 
+Usage: endemic [--log-loc] [--no-log-timestamp] [--log-level LOGLEVEL]
+               [--log-file FILE] [--seed INT] [--config CONFIG]
                [--override CONFIG] TARGET
   Repair TARGET using the endemic genetic method
 

--- a/src/Endemic/Configuration.hs
+++ b/src/Endemic/Configuration.hs
@@ -18,14 +18,13 @@ module Endemic.Configuration
     LogConfig (..),
     RepairConfig (..),
     SearchAlgorithm (..),
-
     -- Global flags
     setGlobalFlags,
     lOGCONFIG,
-
     -- Configuration
     CLIOptions (..),
-    getConfiguration
+    getConfiguration,
+    ProblemDescription (..),
   )
 where
 

--- a/src/Endemic/Configuration/Configure.hs
+++ b/src/Endemic/Configuration/Configure.hs
@@ -1,25 +1,26 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
-module Endemic.Configuration.Configure
-    (
-      lOGCONFIG,
-      getConfiguration,
-      setGlobalFlags,
-      CLIOptions(..),
-    ) where
+{-# LANGUAGE RecordWildCards #-}
 
+module Endemic.Configuration.Configure
+  ( lOGCONFIG,
+    getConfiguration,
+    setGlobalFlags,
+    CLIOptions (..),
+  )
+where
+
+import Data.Aeson (eitherDecodeFileStrict', eitherDecodeStrict')
 import Data.Bifunctor (second)
-import System.Directory (doesFileExist)
-import System.IO.Unsafe ( unsafePerformIO )
-import System.Random (randomIO)
-import Data.IORef ( IORef, newIORef, writeIORef )
-import Endemic.Configuration.Types
-import qualified Data.Map as Map
 import qualified Data.ByteString.Char8 as BS
-import Data.Default (def, Default)
-import Data.Aeson ( eitherDecodeFileStrict', eitherDecodeStrict' )
+import Data.Default (Default, def)
+import Data.IORef (IORef, newIORef, writeIORef)
+import qualified Data.Map as Map
+import Endemic.Configuration.Types
 import Endemic.Types
 import GHC.Generics (Generic)
+import System.Directory (doesFileExist)
+import System.IO.Unsafe (unsafePerformIO)
+import System.Random (randomIO)
 
 -- | Global variable to configure logging
 {-# NOINLINE lOGCONFIG #-}
@@ -45,10 +46,10 @@ readConf fp = do
 -- | Parses the given configuration or reads it from file (if it's a file).
 -- Retursn a default configuration if none is given.
 getConfiguration :: CLIOptions -> IO Configuration
-getConfiguration opts@CLIOptions{optConfig=Nothing} = do
+getConfiguration opts@CLIOptions {optConfig = Nothing} = do
   seed <- randomIO
   addCliArguments opts (materialize (Just conjure)) {randomSeed = Just seed}
-getConfiguration opts@CLIOptions{optConfig=Just fp} =
+getConfiguration opts@CLIOptions {optConfig = Just fp} =
   readConf fp >>= addCliArguments opts . materialize . Just
 
 data CLIOptions = CLIOptions {
@@ -63,12 +64,14 @@ data CLIOptions = CLIOptions {
 
 
 addCliArguments :: CLIOptions -> Configuration -> IO Configuration
-addCliArguments CLIOptions{..} conf = do
-
-  let umLogConf = UmLogConf { umLogLoc = optLogLoc
-                            , umLogLevel = optLogLevel
-                            , umLogTimestamp = optLogTimestamp
-                            , umLogFile = optLogFile }
+addCliArguments CLIOptions {..} conf = do
+  let umLogConf =
+        UmLogConf
+          { umLogLoc = optLogLoc,
+            umLogLevel = optLogLevel,
+            umLogTimestamp = optLogTimestamp,
+            umLogFile = optLogFile
+          }
 
   conf'@Conf {..} <-
     case optOverride of

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+
 module Endemic.Configuration.Types where
 
 import Data.Aeson
@@ -19,7 +20,6 @@ import Deriving.Aeson
 import Endemic.Search.Genetic.Configuration
 import Endemic.Search.PseudoGenetic.Configuration
 import Endemic.Types
-
 
 -- | Logging configuration
 data LogConfig = LogConf
@@ -321,7 +321,7 @@ instance Default OutputConfig where
   def =
     OutputConf
       { locale = Nothing,
-        directory = "./output",
+        directory = "./output-patches-",
         overwrite = True
       }
 
@@ -345,7 +345,6 @@ instance Materializeable OutputConfig where
         directory = fromMaybe directory umDirectory,
         overwrite = fromMaybe overwrite umOverwrite
       }
-
 
 instance Materializeable CompileConfig where
   data Unmaterialized CompileConfig = UmCompConf
@@ -386,8 +385,8 @@ instance Default CompileConfig where
   def =
     CompConf
       { hole_lvl = 0,
-        packages = ["base", "process", "QuickCheck"],
-        importStmts = ["import Prelude"]
+        packages = ["base", "process", "QuickCheck", "tasty"],
+        importStmts = ["import Prelude", "import Test.Tasty"]
       }
 
 -- | Configuration for the checking of repairs
@@ -453,3 +452,12 @@ instance Materializeable LogConfig where
         logTimestamp = fromMaybe logTimestamp umLogTimestamp,
         logFile = mbOverride logFile umLogFile
       }
+
+-- | The Problem Description is generated at runtime, descriping a particular
+-- program to fix.
+data ProblemDescription = ProbDesc
+  { progProblem :: EProblem,
+    exprFitCands :: [ExprFitCand],
+    compConf :: CompileConfig,
+    repConf :: RepairConfig
+  }

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -310,7 +310,9 @@ data OutputConfig = OutputConf
     -- | Which directory to write the patches to.
     directory :: FilePath,
     -- | Whether to overwrite previous patches
-    overwrite :: Bool
+    overwrite :: Bool,
+    -- | Whether to save the patches
+    savePatches :: Bool
   }
   deriving (Show, Eq, Generic)
   deriving
@@ -322,28 +324,31 @@ instance Default OutputConfig where
     OutputConf
       { locale = Nothing,
         directory = "./output-patches-",
-        overwrite = True
+        overwrite = False,
+        savePatches = True
       }
 
 instance Materializeable OutputConfig where
   data Unmaterialized OutputConfig = UmOutConf
     { umLocale :: Maybe TimeLocale,
       umDirectory :: Maybe FilePath,
-      umOverwrite :: Maybe Bool
+      umOverwrite :: Maybe Bool,
+      umSavePatches :: Maybe Bool
     }
     deriving (Show, Eq, Generic)
     deriving
       (FromJSON, ToJSON)
       via CustomJSON '[OmitNothingFields, RejectUnknownFields, FieldLabelModifier '[StripPrefix "um", CamelToSnake]] (Unmaterialized OutputConfig)
 
-  conjure = UmOutConf Nothing Nothing Nothing
+  conjure = UmOutConf Nothing Nothing Nothing Nothing
 
   override c Nothing = c
   override OutputConf {..} (Just UmOutConf {..}) =
     OutputConf
       { locale = mbOverride locale umLocale,
         directory = fromMaybe directory umDirectory,
-        overwrite = fromMaybe overwrite umOverwrite
+        overwrite = fromMaybe overwrite umOverwrite,
+        savePatches = fromMaybe savePatches umSavePatches
       }
 
 instance Materializeable CompileConfig where

--- a/src/Endemic/Search/Genetic/Search.hs
+++ b/src/Endemic/Search/Genetic/Search.hs
@@ -9,6 +9,7 @@ import qualified Control.Monad.Trans.Reader as R
 import Data.List (partition, sortBy, sortOn)
 import Data.Maybe
 import Data.Time.Clock
+import Endemic.Configuration (ProblemDescription (..))
 import Endemic.Search.Genetic.Configuration
 import Endemic.Search.Genetic.GenMonad
 import Endemic.Search.Genetic.Types

--- a/src/Endemic/Search/Genetic/Types.hs
+++ b/src/Endemic/Search/Genetic/Types.hs
@@ -69,23 +69,6 @@ class (Eq g, Outputable g, NFData g) => Chromosome g where
 -- In it's current implementation, the Cache is never cleared.
 type FitnessCache = Map.Map EFix Double
 
--- | The Problem Description is generated at runtime, descriping a particular
--- program to fix.
-data ProblemDescription = ProbDesc
-  { progProblem :: EProblem,
-    exprFitCands :: [ExprFitCand],
-    compConf :: CompileConfig,
-    repConf :: RepairConfig
-  }
-
-describeProblem :: Configuration -> FilePath -> IO ProblemDescription
-describeProblem conf@Conf {compileConfig = cc, repairConfig = repConf} fp = do
-  (compConf, _, [progProblem@EProb {..}]) <- moduleToProb cc fp Nothing
-  exprFitCands <-
-    getExprFitCands compConf $
-      noLoc $ HsLet NoExtField e_ctxt $ noLoc undefVar
-  return $ ProbDesc {..}
-
 -- | The GenMonad resembles the environment in which we run our Genetic Search and it's parts.
 -- It was introduced to reduce the load on various signatures and provide caching easier.
 -- It consists (in this order) of

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -5,7 +5,6 @@
 module Main where
 
 import Data.Maybe (isJust, mapMaybe)
-import Data.Vector (fromList)
 import Endemic (getExprFitCands)
 import Endemic.Diff (applyFixes, getFixBinds, ppDiff)
 import Endemic.Eval

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -11,9 +11,7 @@ import Endemic.Configuration
 import Endemic.Diff (applyFixes, getFixBinds, ppDiff)
 import Endemic.Eval
 import Endemic.Search
-  ( ProblemDescription (..),
-    describeProblem,
-    geneticSearchPlusPostprocessing,
+  ( geneticSearchPlusPostprocessing,
     runGenMonad,
   )
 import Endemic.Search.PseudoGenetic (pseudoGeneticRepair)
@@ -79,7 +77,30 @@ properGenTests =
           fixes <- runGenMonad def desc 69420 geneticSearchPlusPostprocessing
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
               fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
-          fixDiffs @?= expected
+          take 1 fixDiffs @?= expected,
+      localOption (mkTimeout 180_000_000) $
+        testCase "Repair TastyMix" $ do
+          let toFix = "tests/cases/TastyMix.hs"
+              repair_target = Nothing
+              expected =
+                map
+                  unlines
+                  [ [ "diff --git a/tests/cases/TastyMix.hs b/tests/cases/TastyMix.hs",
+                      "--- a/tests/cases/TastyMix.hs",
+                      "+++ b/tests/cases/TastyMix.hs",
+                      "@@ -7,1 +7,1 @@ x = 2",
+                      "-x = 2",
+                      "+x = 3"
+                    ]
+                  ]
+
+          (_, modul, [EProb {..}]) <-
+            moduleToProb (def {packages = def packages ++ ["tasty", "tasty-hunit"]}) toFix repair_target
+          desc <- describeProblem def toFix
+          fixes <- runGenMonad def desc 69420 geneticSearchPlusPostprocessing
+          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
+              fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
+          take 1 fixDiffs @?= expected
     ]
 
 genTests =
@@ -102,7 +123,8 @@ genTests =
                   ]
 
           (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
-          fixes <- pseudoGeneticRepair def {searchAlgorithm = PseudoGenetic def} tp
+          desc <- describeProblem def toFix
+          fixes <- pseudoGeneticRepair def desc
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
               fixDiffs = map (concatMap ppDiff . snd . applyFixes mod . getFixBinds) fixProgs
           fixDiffs @?= expected,
@@ -123,7 +145,8 @@ genTests =
                   ]
 
           (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
-          fixes <- pseudoGeneticRepair def {searchAlgorithm = PseudoGenetic def} tp
+          desc <- describeProblem def toFix
+          fixes <- pseudoGeneticRepair def desc
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
               fixDiffs = map (concatMap ppDiff . snd . applyFixes mod . getFixBinds) fixProgs
           fixDiffs @?= expected,
@@ -144,7 +167,8 @@ genTests =
                   ]
 
           (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
-          fixes <- pseudoGeneticRepair def {searchAlgorithm = PseudoGenetic def} tp
+          desc <- describeProblem def toFix
+          fixes <- pseudoGeneticRepair def desc
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
               fixDiffs = map (concatMap ppDiff . snd . applyFixes mod . getFixBinds) fixProgs
           fixDiffs @?= expected

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -6,17 +6,18 @@ module Main where
 
 import Control.Arrow
 import Data.Bits (finiteBitSize)
+import Data.Default
 import Data.Dynamic (fromDynamic)
 import Data.List (find)
 import qualified Data.Map as Map
 import Data.Maybe (isJust, mapMaybe)
 import Data.Tree
 import Data.Tuple (swap)
+import Endemic.Configuration
 import Endemic.Diff
 import Endemic.Eval
 import Endemic.Repair
 import Endemic.Traversals
-import Endemic.Configuration
 import Endemic.Types
 import Endemic.Util
 import GhcPlugins (GenLocated (L), getLoc, unLoc)
@@ -25,7 +26,6 @@ import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 import Trace.Hpc.Mix
-import Data.Default
 
 tests :: TestTree
 tests =

--- a/tests/cases/TastyFix.hs
+++ b/tests/cases/TastyFix.hs
@@ -1,0 +1,14 @@
+module TastyFix where
+
+import Test.Tasty
+import Test.Tasty.HUnit (testCase, (@?=))
+
+x :: Int
+x = 2
+
+-- We scan mix and match now
+prop_bigEnough :: Bool
+prop_bigEnough = x > 2
+
+test :: TestTree
+test = testCase "Test 1" (x @?= 3)

--- a/tests/cases/TastyMix.hs
+++ b/tests/cases/TastyMix.hs
@@ -1,10 +1,14 @@
-module TastyFix where
+module TastyMix where
 
 import Test.Tasty
 import Test.Tasty.HUnit (testCase, (@?=))
 
 x :: Int
 x = 2
+
+-- We scan mix and match now
+prop_bigEnough :: Bool
+prop_bigEnough = x > 2
 
 test :: TestTree
 test = testCase "Test 1" (x @?= 3)


### PR DESCRIPTION
We can now fix programs with tasty `TestTree`s, as determined by the type. We can also mix and match. See `TastyFix` and `TastyMix` for examples.

Based off of the #24 branch, so we'll merge that one first.