### PR TITLE
[WIP] Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+dist*/
+fake_targets/
+cabal.project.local
+*.mix
+
+*.o
+*.hi
+
+.DS_Store
+
+output-patches-*
+
+log.txt 
+*.log

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,67 @@
+name: Docker-CI
+
+# Taken from https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'master'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            tritlo/endemic
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args:
+            HASKELL_VERSION: 8.10.4
+            ENDEMIC_VERSION: 0.0.1
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ LABEL builder=true
 LABEL maintainer="L.H.Applis@tu-delft.nl"
 
 WORKDIR /builder
+COPY ./Endemic.cabal /builder/
+RUN cabal update
+RUN cabal build --dependencies-only Endemic
 
 COPY ./src /builder/src
 COPY ./tests /builder/tests
-COPY ./Endemic.cabal /builder/
 
 #TODO: Can we freeze the cabal update here somehow? 
-RUN cabal update
 
 WORKDIR /builder
 RUN cabal build
@@ -59,6 +60,7 @@ RUN mkdir ${REPAIR_TARGET}
 
 # Copy the Entrypoint
 COPY ./entrypoint.sh /app/
+WORKDIR /app
 RUN chmod +x /app/entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ To run the program, ensure that the `check-helpers` library is installed by runn
 $ cabal run endemic -- examples/BrokenModule.hs
 ```
 
+Optionally, you can use Docker: 
+
+```
+$ docker-compose up --build
+```
+
 For more options see #Usage and the `--help` flag.
 
 to see it in action on the `foldl (-) 0` example. This produces the following:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ echo "Starting Repair-Docker - Building the command"
 # it is stitched together with any flag set in docker. 
 
 # Repairtarget must be set, otherwise it makes little sense
-commandCollector="cabal run endemic -- $REPAIR_TARGET"
+commandCollector="/app/endemic $REPAIR_TARGET"
 
 if [ -z ${LOG_LEVEL+x} ]; 
 then echo "Log-Level is not set"; 


### PR DESCRIPTION
Features 

- Two stage dockerbuild using the runnable-created, not cabal-run 
- due to cabal run, the output was cached until cabal exited, which is now gone
- Arguments for GHC and Endemic Version 
- Some Labels on the Docker File 
- CI

Problems: 

- The following error is shown on `docker-compose up --build` : `Endemic_Example_1  | endemic: attempting to use module ‘main:Check.Helpers’ (./Check/Helpers.hs) which is not loaded` after which the program exits. 


Related Issues: #17 and #20 will be addressed (or discarded) later. 