### PR TITLE
Fix out-of-scope errors (#14)

### DIFF
--- a/src/Endemic/Configuration.hs
+++ b/src/Endemic/Configuration.hs
@@ -24,11 +24,11 @@ module Endemic.Configuration
     -- Generating good random seeds for quickcheck
     newQCSeed,
     setQCSeedGenSeed,
-
     -- Configuration
     CLIOptions (..),
     getConfiguration,
     ProblemDescription (..),
+    module Endemic.Configuration.Types,
   )
 where
 

--- a/src/Endemic/Configuration.hs
+++ b/src/Endemic/Configuration.hs
@@ -27,6 +27,7 @@ module Endemic.Configuration
     -- Configuration
     CLIOptions (..),
     getConfiguration,
+    getConfiguration',
     ProblemDescription (..),
     module Endemic.Configuration.Types,
   )

--- a/src/Endemic/Repair.hs
+++ b/src/Endemic/Repair.hs
@@ -266,7 +266,7 @@ repairAttempt cc rc tp@EProb {..} efcs = collectStats $ do
         . Map.unionsWith (+)
         . map toInvokes
         . catMaybes
-        <$> traceTargets rc cc prog_at_ty ps_w_ce
+        <$> traceTargets rc cc tp prog_at_ty ps_w_ce
   -- We then remove suggested holes that are unlikely to help (naively for now
   -- in the sense that we remove only holes which did not get evaluated at all,
   -- so they are definitely not going to matter).

--- a/src/Endemic/Search/Genetic/Configuration.hs
+++ b/src/Endemic/Search/Genetic/Configuration.hs
@@ -46,7 +46,7 @@ instance Default GeneticConfiguration where
   def = GConf {..}
     where
       mutationRate = 0.2
-      crossoverRate = 0.05
+      crossoverRate = 0.4
       iterations = 50
       populationSize = 64
       timeoutInMinutes = 5
@@ -54,7 +54,7 @@ instance Default GeneticConfiguration where
       tournamentConfiguration = Nothing
       islandConfiguration = Nothing
       -- T
-      dropRate = 0.2
+      dropRate = 0.05
       tryMinimizeFixes = False -- Not implemented
       replaceWinners = True
       useParallelMap = True

--- a/src/Endemic/Search/Genetic/GenMonad.hs
+++ b/src/Endemic/Search/Genetic/GenMonad.hs
@@ -182,10 +182,9 @@ efixCrossover f_a f_b = do
     -- For empty chromosomes, there is no crossover possible
     crossoverLists gen [] [] = ([], [], gen)
     -- For single-gene chromosomes, there is no crossover possible
-    crossoverLists gen [a] [b] = ([a], [b], gen)
     crossoverLists gen as bs =
-      let (crossoverPointA, gen') = uniformR (1, length as) gen
-          (crossoverPointB, gen'') = uniformR (1, length bs) gen'
+      let (crossoverPointA, gen') = uniformR (0, length as) gen
+          (crossoverPointB, gen'') = uniformR (0, length bs) gen'
           (part1A, part2A) = splitAt crossoverPointA as
           (part1B, part2B) = splitAt crossoverPointB bs
        in (mf' part1A part2B, mf' part1B part2A, gen'')

--- a/src/Endemic/Search/Genetic/GenMonad.hs
+++ b/src/Endemic/Search/Genetic/GenMonad.hs
@@ -51,11 +51,12 @@ instance Chromosome EFix where
     ProbDesc {..} <- liftDesc R.ask
     GConf {..} <- liftConf R.ask
     gen <- getGen
-    flips <- mapM (\e -> (e,) . (not (Map.null e) &&) <$> tossCoin dropRate) exprs
+    flips <- mapM (\e -> (e,) <$> tossCoin dropRate) exprs
     let (to_drop_w_inds, to_mutate_w_inds) = partition (snd . snd) $ zip [0 :: Int ..] flips
         (to_mutate_inds, to_mutate) = map fst <$> unzip to_mutate_w_inds
         (to_drop_inds, to_drop) = map fst <$> unzip to_drop_w_inds
         drop' :: EFix -> StdGen -> EFix
+        drop' e _ | Map.null e = e
         drop' e g =
           let Just (key_to_drop, _) = pickElementUniform (Map.keys e) g
            in Map.delete key_to_drop e
@@ -181,7 +182,6 @@ efixCrossover f_a f_b = do
       ([(SrcSpan, HsExpr GhcPs)], [(SrcSpan, HsExpr GhcPs)], g)
     -- For empty chromosomes, there is no crossover possible
     crossoverLists gen [] [] = ([], [], gen)
-    -- For single-gene chromosomes, there is no crossover possible
     crossoverLists gen as bs =
       let (crossoverPointA, gen') = uniformR (0, length as) gen
           (crossoverPointB, gen'') = uniformR (0, length bs) gen'

--- a/src/Endemic/Search/Genetic/Search.hs
+++ b/src/Endemic/Search/Genetic/Search.hs
@@ -145,11 +145,12 @@ geneticSearch = collectStats $ do
                 ++ show (length winners)
                 ++ " Results)"
             )
-          liftIO $ do logStr AUDIT "Current gen:"
-                      mapM (logOut AUDIT) pop
-                      logStr AUDIT "Next gen:"
-                      mapM (logOut AUDIT) nextPop
-           -- End Early when any result is ok
+          liftIO $ do
+            logStr AUDIT "Current gen:"
+            mapM (logOut AUDIT) pop
+            logStr AUDIT "Next gen:"
+            mapM (logOut AUDIT) nextPop
+          -- End Early when any result is ok
           if not (null winners) && stopOnResults conf
             then return winners
             else -- Otherwise do recursive step

--- a/src/Endemic/Search/Genetic/Search.hs
+++ b/src/Endemic/Search/Genetic/Search.hs
@@ -145,7 +145,11 @@ geneticSearch = collectStats $ do
                 ++ show (length winners)
                 ++ " Results)"
             )
-          -- End Early when any result is ok
+          liftIO $ do logStr AUDIT "Current gen:"
+                      mapM (logOut AUDIT) pop
+                      logStr AUDIT "Next gen:"
+                      mapM (logOut AUDIT) nextPop
+           -- End Early when any result is ok
           if not (null winners) && stopOnResults conf
             then return winners
             else -- Otherwise do recursive step

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -38,7 +38,7 @@ tastyFixTests :: TestTree
 tastyFixTests =
   testGroup
     "Tasty fix tests"
-    [ localOption (mkTimeout 10_000_000) $
+    [ localOption (mkTimeout 30_000_000) $
         testCase "Repair TastyFix" $ do
           let toFix = "tests/cases/TastyFix.hs"
               repair_target = Nothing
@@ -62,7 +62,7 @@ tastyFixTests =
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
               fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
           fixDiffs @?= expected,
-      localOption (mkTimeout 10_000_000) $
+      localOption (mkTimeout 30_000_000) $
         testCase "Repair TastyMix" $ do
           let toFix = "tests/cases/TastyMix.hs"
               repair_target = Nothing
@@ -92,7 +92,7 @@ properGenTests :: TestTree
 properGenTests =
   testGroup
     "proper generation tests"
-    [ localOption (mkTimeout 300_000_000) $
+    [ localOption (mkTimeout 480_000_000) $
         testCase "Repair ThreeFixes w/ randomness" $ do
           let toFix = "tests/cases/ThreeFixes.hs"
               repair_target = Nothing
@@ -107,11 +107,19 @@ properGenTests =
                       "+brokenPair = (3, 4, 5)"
                     ]
                   ]
+              config@Conf {..} =
+                materialize $
+                  Just $
+                    def
+                      { umSearchAlgorithm =
+                          Just (UmGenetic $ def {umTimeoutInMinutes = Just 15})
+                      }
+              Conf {searchAlgorithm = Genetic genConf} = config
 
           setQCSeedGenSeed tEST_SEED
-          (_, modul, [EProb {..}]) <- moduleToProb def toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- runGenMonad def desc 69420 geneticSearchPlusPostprocessing
+          (_, modul, [EProb {..}]) <- moduleToProb compileConfig toFix repair_target
+          desc <- describeProblem config toFix
+          fixes <- runGenMonad genConf desc 69420 geneticSearchPlusPostprocessing
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
               fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
           fixDiffs @?= expected

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -344,7 +344,7 @@ traceTests =
           [failed_prop] <- failingProps def cc tp
           Just counter_example <- propCounterExample def cc tp failed_prop
           Just Node {subForest = [tree@Node {rootLabel = (tl, tname)}]} <-
-            traceTarget def cc e_prog failed_prop counter_example
+            traceTarget def cc tp e_prog failed_prop counter_example
           expr <- runJustParseExpr cc wrong_prog
           getLoc expr @?= mkInteractive tl
           all ((== 1) . snd) (concatMap snd $ flatten tree) @? "All subexpressions should be touched only once!",
@@ -380,7 +380,7 @@ traceTests =
           -- We generate the trace
           let prog_at_ty = progAtTy e_prog e_ty
           tcorrel <- buildTraceCorrel cc prog_at_ty
-          Just res <- traceTarget def cc prog_at_ty failed_prop counter_example_args
+          Just res <- traceTarget def cc tp prog_at_ty failed_prop counter_example_args
           let eMap = Map.fromList $ map (getLoc &&& showUnsafe) $ flattenExpr prog_at_ty
               chain l = tcorrel Map.!? l >>= (eMap Map.!?)
               trc = map (\(s, r) -> (chain $ mkInteractive s, r, maximum $ map snd r)) $ flatten res

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -41,8 +41,8 @@ tests =
     ]
 
 -- | Chosen fairly by Random.org
-tEST_SEED :: Int
-tEST_SEED = 490_100_041
+tESTSEED :: Int
+tESTSEED = 490_100_041
 
 -- We can only do the inverse for ints up to 64, so we only support a maximum
 -- of 64 props!
@@ -96,7 +96,7 @@ repairTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp@EProb {..} <- translate cc rp
           fixes <- repair cc def tp
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
@@ -155,7 +155,7 @@ repairTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           fixes <- map (trim . showUnsafe) <$> (translate def rp >>= repair def def)
           not (null fixes) @? "No fix found"
     ]
@@ -187,7 +187,7 @@ failingPropsTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp <- translate def rp
           failed_props <- failingProps def def tp
           -- Only the first prop should be failing (due to an infinite loop)
@@ -217,7 +217,7 @@ failingPropsTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp <- translate cc rp
           failed_props <- failingProps def cc tp
           map showUnsafe failed_props @?= props
@@ -247,7 +247,7 @@ counterExampleTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp <- translate cc rp
           [failed_prop] <- failingProps def cc tp
           Just [counter_example] <- propCounterExample def cc tp failed_prop
@@ -276,7 +276,7 @@ counterExampleTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp <- translate cc rp
           [failed_prop] <- failingProps def cc tp
           Just counter_example_args <- propCounterExample def cc tp failed_prop
@@ -311,7 +311,7 @@ counterExampleTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp <- translate cc rp
           [failed_prop] <- failingProps def cc tp
           -- Only the first prop should be failing (due to an infinite loop)
@@ -339,7 +339,7 @@ traceTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp@EProb {..} <- translate cc rp
           [failed_prop] <- failingProps def cc tp
           Just counter_example <- propCounterExample def cc tp failed_prop
@@ -373,7 +373,7 @@ traceTests =
                     r_prog = wrong_prog,
                     r_props = props
                   }
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           tp@EProb {..} <- translate cc rp
           [failed_prop] <- failingProps def cc tp
           Just counter_example_args <- propCounterExample def cc tp failed_prop
@@ -456,7 +456,7 @@ moduleTests =
                     ]
                   ]
 
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
           fixes <- repair cc' def tp
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
@@ -484,7 +484,7 @@ moduleTests =
                       " gcd' a b = if (a > b) then gcd' (a - b) b else gcd' a (b - a)"
                     ]
                   ]
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
           fixes <- repair cc' def tp
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes
@@ -506,7 +506,7 @@ moduleTests =
                     ]
                   ]
 
-          setQCSeedGenSeed tEST_SEED
+          setQCSeedGenSeed tESTSEED
           (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
           fixes <- repair cc' def tp
           let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) fixes

--- a/tests/cases/ThreeFixes.hs
+++ b/tests/cases/ThreeFixes.hs
@@ -18,3 +18,6 @@ prop_4 = a < 5 && b < 5 && c > 0
 
 brokenPair :: (Int, Int, Int)
 brokenPair = (1, 2, 3)
+
+sixInThreeFixes :: Int
+sixInThreeFixes = 6

--- a/tests/cases/TwoFixes.hs
+++ b/tests/cases/TwoFixes.hs
@@ -10,3 +10,8 @@ prop_3 = a < 5 && b < 5
 
 brokenPair :: (Int, Int)
 brokenPair = (1, 2)
+
+-- We had an error where the context was not being passed into the trace, so
+-- this would result in an out-of-scope error:
+fiveInTwoFixes :: Int
+fiveInTwoFixes = 7


### PR DESCRIPTION
We fixed the scope issue, but we don't get the expected results from the `ThreeFixes` test when `six = 6` is in scope. Checking to see if it happens also in CI.