### PR TITLE
Add Random and Exhaustive Search

### DIFF
--- a/Endemic.cabal
+++ b/Endemic.cabal
@@ -28,7 +28,8 @@ library
                    Endemic.Util,
                    Endemic.Search,
                    Endemic.Search.PseudoGenetic,
-                   Endemic.Search.Genetic
+                   Endemic.Search.Genetic,
+                   Endemic.Search.Random
   other-modules: Endemic.Configuration.Configure,
                  Endemic.Configuration.Types,
                  Endemic.Configuration.Materializeable,
@@ -39,7 +40,9 @@ library
                  Endemic.Search.Genetic.Types,
                  Endemic.Search.Genetic.Utils
                  Endemic.Search.PseudoGenetic.Configuration,
-                 Endemic.Search.PseudoGenetic.Search
+                 Endemic.Search.PseudoGenetic.Search,
+                 Endemic.Search.Random.Configuration,
+                 Endemic.Search.Random.Search
   build-depends: base >= 4 && < 5,
                  ghc >= 8 && < 9,
                  ghc-boot >= 8 && < 9,

--- a/Endemic.cabal
+++ b/Endemic.cabal
@@ -29,7 +29,8 @@ library
                    Endemic.Search,
                    Endemic.Search.PseudoGenetic,
                    Endemic.Search.Genetic,
-                   Endemic.Search.Random
+                   Endemic.Search.Random,
+                   Endemic.Search.Exhaustive
   other-modules: Endemic.Configuration.Configure,
                  Endemic.Configuration.Types,
                  Endemic.Configuration.Materializeable,
@@ -42,7 +43,9 @@ library
                  Endemic.Search.PseudoGenetic.Configuration,
                  Endemic.Search.PseudoGenetic.Search,
                  Endemic.Search.Random.Configuration,
-                 Endemic.Search.Random.Search
+                 Endemic.Search.Random.Search,
+                 Endemic.Search.Exhaustive.Configuration,
+                 Endemic.Search.Exhaustive.Search
   build-depends: base >= 4 && < 5,
                  ghc >= 8 && < 9,
                  ghc-boot >= 8 && < 9,

--- a/resources/big_sample_config.json
+++ b/resources/big_sample_config.json
@@ -1,54 +1,54 @@
 {
-  "compile_config": {
-    "import_stmts": [
-      "import Prelude"
-    ],
-    "packages": [
-      "base"
-    ],
-    "hole_lvl": 0
-  },
-  "repair_config": {
-    "par_checks": true,
-    "use_interpreted": true,
-    "timeout": 1000000
-  },
-  "output_config": {
-    "locale": null,
-    "directory": "./output-patches-",
-    "overwrite": false,
-    "save_patches": true
-  },
-  "search_algorithm": {
-    "tag": "Genetic",
-    "contents": {
-      "mutation_rate": 0.1,
-      "crossover_rate": 0.4,
-      "iterations": 50,
-      "population_size": 64,
-      "timeout_in_minutes": 5,
-      "stop_on_results": false,
-      "tournament_configuration": {
-        "t_size": 8,
-        "t_rounds": 8
-      },
-      "island_configuration": {
-        "islands": 4,
-        "migration_interval": 8,
-        "migration_size": 4,
-        "ringwise_migration": true
-      },
-      "drop_rate": 0.25,
-      "try_minimize_fixes": false,
-      "replace_winners": true,
-      "use_parallel_map": true
-    }
-  },
-  "log_config": {
-    "log_loc": false,
-    "log_level": "WARN",
-    "log_timestamp": true,
-    "log_file": null
-  },
-  "random_seed": 42
+        "compile_config": {
+                "import_stmts": [
+                        "import Prelude"
+                ],
+                "packages": [
+                        "base"
+                ],
+                "hole_lvl": 0
+        },
+        "repair_config": {
+                "par_checks": true,
+                "use_interpreted": true,
+                "timeout": 1000000
+        },
+        "output_config": {
+                "locale": null,
+                "directory": "./output-patches-",
+                "overwrite": false,
+                "save_patches": true
+        },
+        "search_algorithm": {
+                "tag": "Genetic",
+                "contents": {
+                        "mutation_rate": 0.1,
+                        "crossover_rate": 0.4,
+                        "iterations": 50,
+                        "population_size": 64,
+                        "timeout_in_seconds": 300,
+                        "stop_on_results": false,
+                        "tournament_configuration": {
+                                "t_size": 8,
+                                "t_rounds": 8
+                        },
+                        "island_configuration": {
+                                "islands": 4,
+                                "migration_interval": 8,
+                                "migration_size": 4,
+                                "ringwise_migration": true
+                        },
+                        "drop_rate": 0.25,
+                        "try_minimize_fixes": false,
+                        "replace_winners": true,
+                        "use_parallel_map": true
+                }
+        },
+        "log_config": {
+                "log_loc": false,
+                "log_level": "WARN",
+                "log_timestamp": true,
+                "log_file": null
+        },
+        "random_seed": 42
 }

--- a/resources/docker_config.json
+++ b/resources/docker_config.json
@@ -1,40 +1,40 @@
 {
-  "compile_config": {
-    "import_stmts": [
-      "import Prelude"
-    ],
-    "packages": [
-      "base",
-      "process",
-      "check-helpers",
-      "QuickCheck"
-    ],
-    "hole_lvl": 0
-  },
-  "repair_config": {
-    "par_checks": true,
-    "use_interpreted": true
-  },
-  "output_config": {
-    "locale": null,
-    "directory": "/output/output-patches-",
-    "overwrite": false,
-    "save_patches": true
-  },
-  "search_algorithm": {
-    "tag": "Genetic",
-    "contents": {
-      "mutation_rate": 0.3,
-      "crossover_rate": 0.4,
-      "iterations": 50,
-      "population_size": 64,
-      "timeout_in_minutes": 5,
-      "stop_on_results": false,
-      "drop_rate": 0.25,
-      "try_minimize_fixes": false,
-      "replace_winners": true,
-      "use_parallel_map": true
-    }
-  },
-  "random_seed": 42
+        "compile_config": {
+                "import_stmts": [
+                        "import Prelude"
+                ],
+                "packages": [
+                        "base",
+                        "process",
+                        "check-helpers",
+                        "QuickCheck"
+                ],
+                "hole_lvl": 0
+        },
+        "repair_config": {
+                "par_checks": true,
+                "use_interpreted": true
+        },
+        "output_config": {
+                "locale": null,
+                "directory": "/output/output-patches-",
+                "overwrite": false,
+                "save_patches": true
+        },
+        "search_algorithm": {
+                "tag": "Genetic",
+                "contents": {
+                        "mutation_rate": 0.3,
+                        "crossover_rate": 0.4,
+                        "iterations": 50,
+                        "population_size": 64,
+                        "timeout_in_seconds": 300,
+                        "stop_on_results": false,
+                        "drop_rate": 0.25,
+                        "try_minimize_fixes": false,
+                        "replace_winners": true,
+                        "use_parallel_map": true
+                }
+        },
+        "random_seed": 42
 }

--- a/resources/exhaustive_search_config.json
+++ b/resources/exhaustive_search_config.json
@@ -1,0 +1,37 @@
+{
+        "compile_config": {
+                "import_stmts": [
+                        "import Prelude"
+                ],
+                "packages": [
+                        "base"
+                ],
+                "hole_lvl": 0
+        },
+        "repair_config": {
+                "par_checks": true,
+                "use_interpreted": true,
+                "timeout": 1000000
+        },
+        "output_config": {
+                "locale": null,
+                "directory": "./output-patches-",
+                "overwrite": false,
+                "save_patches": true
+        },
+        "search_algorithm": {
+                "tag": "Exhaustive",
+                "contents": {
+                        "exh_search_budget": 300,
+                        "exh_stop_on_results": true,
+                        "exh_batch_size": 10
+                }
+        },
+        "log_config": {
+                "log_loc": false,
+                "log_level": "WARN",
+                "log_timestamp": true,
+                "log_file": null
+        },
+        "random_seed": -911372734310229019
+}

--- a/resources/random_search_config.json
+++ b/resources/random_search_config.json
@@ -1,0 +1,38 @@
+{
+        "compile_config": {
+                "import_stmts": [
+                        "import Prelude"
+                ],
+                "packages": [
+                        "base"
+                ],
+                "hole_lvl": 0
+        },
+        "repair_config": {
+                "par_checks": true,
+                "use_interpreted": true,
+                "timeout": 1000000
+        },
+        "output_config": {
+                "locale": null,
+                "directory": "./output-patches-",
+                "overwrite": false,
+                "save_patches": true
+        },
+        "search_algorithm": {
+                "tag": "Random",
+                "contents": {
+                        "rand_search_budget": 300,
+                        "rand_max_fix_size": 10,
+                        "rand_ignore_failing": true,
+                        "rand_stop_on_results": true
+                }
+        },
+        "log_config": {
+                "log_loc": false,
+                "log_level": "WARN",
+                "log_timestamp": true,
+                "log_file": null
+        },
+        "random_seed": -3573107736776895748
+}

--- a/resources/sample_config.json
+++ b/resources/sample_config.json
@@ -1,44 +1,44 @@
 {
-  "compile_config": {
-    "import_stmts": [
-      "import Prelude"
-    ],
-    "packages": [
-      "base"
-    ],
-    "hole_lvl": 0
-  },
-  "repair_config": {
-    "par_checks": true,
-    "use_interpreted": true,
-    "timeout": 1000000
-  },
-  "output_config": {
-    "locale": null,
-    "directory": "./output-patches-",
-    "overwrite": false,
-    "save_patches": true
-  },
-  "search_algorithm": {
-    "tag": "Genetic",
-    "contents": {
-      "mutation_rate": 0.1,
-      "crossover_rate": 0.4,
-      "iterations": 50,
-      "population_size": 64,
-      "timeout_in_minutes": 5,
-      "stop_on_results": false,
-      "drop_rate": 0.25,
-      "try_minimize_fixes": false,
-      "replace_winners": true,
-      "use_parallel_map": true
-    }
-  },
-  "log_config": {
-    "log_loc": false,
-    "log_level": "WARN",
-    "log_timestamp": true,
-    "log_file": null
-  },
-  "random_seed": 42
+        "compile_config": {
+                "import_stmts": [
+                        "import Prelude"
+                ],
+                "packages": [
+                        "base"
+                ],
+                "hole_lvl": 0
+        },
+        "repair_config": {
+                "par_checks": true,
+                "use_interpreted": true,
+                "timeout": 1000000
+        },
+        "output_config": {
+                "locale": null,
+                "directory": "./output-patches-",
+                "overwrite": false,
+                "save_patches": true
+        },
+        "search_algorithm": {
+                "tag": "Genetic",
+                "contents": {
+                        "mutation_rate": 0.1,
+                        "crossover_rate": 0.4,
+                        "iterations": 50,
+                        "population_size": 64,
+                        "timeout_in_seconds": 300,
+                        "stop_on_results": false,
+                        "drop_rate": 0.25,
+                        "try_minimize_fixes": false,
+                        "replace_winners": true,
+                        "use_parallel_map": true
+                }
+        },
+        "log_config": {
+                "log_loc": false,
+                "log_level": "WARN",
+                "log_timestamp": true,
+                "log_file": null
+        },
+        "random_seed": 42
 }

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -338,3 +338,7 @@ data ProblemDescription = ProbDesc
 
 setProg :: ProblemDescription -> EExpr -> ProblemDescription
 setProg desc@ProbDesc {progProblem = pp} prog = desc {progProblem = pp {e_prog = prog}}
+
+-- Inline version of setProg
+(~>) :: ProblemDescription -> EExpr -> ProblemDescription
+(~>) = setProg

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -335,3 +335,6 @@ data ProblemDescription = ProbDesc
     compConf :: CompileConfig,
     repConf :: RepairConfig
   }
+
+setProg :: ProblemDescription -> EExpr -> ProblemDescription
+setProg desc@ProbDesc {progProblem = pp} prog = desc {progProblem = pp {e_prog = prog}}

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -23,6 +23,7 @@ import Endemic.Search.Genetic.Configuration
 import Endemic.Search.PseudoGenetic.Configuration
 import Endemic.Search.Random.Configuration
 import Endemic.Types
+import GHC (ParsedModule)
 
 -- | Logging configuration
 data LogConfig = LogConf
@@ -333,7 +334,9 @@ data ProblemDescription = ProbDesc
   { progProblem :: EProblem,
     exprFitCands :: [ExprFitCand],
     compConf :: CompileConfig,
-    repConf :: RepairConfig
+    repConf :: RepairConfig,
+    -- | The parsed module, if available
+    probModule :: Maybe ParsedModule
   }
 
 setProg :: ProblemDescription -> EExpr -> ProblemDescription

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -19,6 +19,7 @@ import Data.Time.Format
 import Data.Time.LocalTime
 import Deriving.Aeson
 import Endemic.Configuration.Materializeable
+import Endemic.Search.Exhaustive.Configuration
 import Endemic.Search.Genetic.Configuration
 import Endemic.Search.PseudoGenetic.Configuration
 import Endemic.Search.Random.Configuration
@@ -123,6 +124,7 @@ data SearchAlgorithm
   = Genetic GeneticConfiguration
   | PseudoGenetic PseudoGenConf
   | Random RandomConf
+  | Exhaustive ExhaustiveConf
   deriving (Show, Eq, Generic)
   deriving
     (FromJSON, ToJSON)
@@ -136,6 +138,7 @@ instance Materializeable SearchAlgorithm where
     = UmGenetic (Unmaterialized GeneticConfiguration)
     | UmPseudoGenetic (Unmaterialized PseudoGenConf)
     | UmRandom (Unmaterialized RandomConf)
+    | UmExhaustive (Unmaterialized ExhaustiveConf)
     deriving (Show, Eq, Generic)
     deriving
       (FromJSON, ToJSON)
@@ -156,12 +159,16 @@ instance Materializeable SearchAlgorithm where
     PseudoGenetic $ override conf (Just pgc)
   override (Random conf) (Just (UmRandom pgc)) =
     Random $ override conf (Just pgc)
+  override (Exhaustive conf) (Just (UmExhaustive pgc)) =
+    Exhaustive $ override conf (Just pgc)
   override _ (Just (UmPseudoGenetic psc)) =
     PseudoGenetic $ materialize $ Just psc
   override _ (Just (UmGenetic gc)) =
     Genetic $ materialize $ Just gc
   override _ (Just (UmRandom r)) =
     Random $ materialize $ Just r
+  override _ (Just (UmExhaustive e)) =
+    Exhaustive $ materialize $ Just e
 
 -- | Configuration for the output
 data OutputConfig = OutputConf

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -21,6 +21,7 @@ import Deriving.Aeson
 import Endemic.Configuration.Materializeable
 import Endemic.Search.Genetic.Configuration
 import Endemic.Search.PseudoGenetic.Configuration
+import Endemic.Search.Random.Configuration
 import Endemic.Types
 
 -- | Logging configuration
@@ -120,6 +121,7 @@ instance Materializeable Configuration where
 data SearchAlgorithm
   = Genetic GeneticConfiguration
   | PseudoGenetic PseudoGenConf
+  | Random RandomConf
   deriving (Show, Eq, Generic)
   deriving
     (FromJSON, ToJSON)
@@ -132,6 +134,7 @@ instance Materializeable SearchAlgorithm where
   data Unmaterialized SearchAlgorithm
     = UmGenetic (Unmaterialized GeneticConfiguration)
     | UmPseudoGenetic (Unmaterialized PseudoGenConf)
+    | UmRandom (Unmaterialized RandomConf)
     deriving (Show, Eq, Generic)
     deriving
       (FromJSON, ToJSON)
@@ -150,10 +153,14 @@ instance Materializeable SearchAlgorithm where
     Genetic $ override conf (Just gc)
   override (PseudoGenetic conf) (Just (UmPseudoGenetic pgc)) =
     PseudoGenetic $ override conf (Just pgc)
+  override (Random conf) (Just (UmRandom pgc)) =
+    Random $ override conf (Just pgc)
   override _ (Just (UmPseudoGenetic psc)) =
     PseudoGenetic $ materialize $ Just psc
   override _ (Just (UmGenetic gc)) =
     Genetic $ materialize $ Just gc
+  override _ (Just (UmRandom r)) =
+    Random $ materialize $ Just r
 
 -- | Configuration for the output
 data OutputConfig = OutputConf

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -343,5 +343,5 @@ setProg :: ProblemDescription -> EExpr -> ProblemDescription
 setProg desc@ProbDesc {progProblem = pp} prog = desc {progProblem = pp {e_prog = prog}}
 
 -- Inline version of setProg
-(~>) :: ProblemDescription -> EExpr -> ProblemDescription
-(~>) = setProg
+(<~) :: ProblemDescription -> EExpr -> ProblemDescription
+(<~) = setProg

--- a/src/Endemic/Eval.hs
+++ b/src/Endemic/Eval.hs
@@ -824,7 +824,8 @@ getExprFitCands cc expr = runGhc (Just libdir) $ do
 
 describeProblem :: Configuration -> FilePath -> IO ProblemDescription
 describeProblem conf@Conf {compileConfig = cc, repairConfig = repConf} fp = do
-  (compConf, _, [progProblem@EProb {..}]) <- moduleToProb cc fp Nothing
+  (compConf, modul, [progProblem@EProb {..}]) <- moduleToProb cc fp Nothing
+  let probModule = Just modul
   exprFitCands <-
     getExprFitCands compConf $
       noLoc $ HsLet NoExtField e_ctxt $ noLoc undefVar

--- a/src/Endemic/Eval.hs
+++ b/src/Endemic/Eval.hs
@@ -629,7 +629,7 @@ genCandTys cc bcat cands = runGhc (Just libdir) $ do
 -- | Right True means that all the properties hold, while Right False mean that
 -- There is some error or infinite loop.
 -- Left bs indicates that the properties as ordered by bs are the ones that hold
-runCheck :: RepairConfig -> Either [ValsAndRefs] Dynamic -> IO (Either [Bool] Bool)
+runCheck :: RepairConfig -> Either [ValsAndRefs] Dynamic -> IO TestSuiteResult
 runCheck _ (Left _) = return (Right False)
 runCheck RepConf {..} (Right dval) =
   -- Note! By removing the call to "isSuccess" in the buildCheckExprAtTy we

--- a/src/Endemic/Repair.hs
+++ b/src/Endemic/Repair.hs
@@ -10,7 +10,6 @@
 -- Stability   : experimental
 --
 -- This is a highlevel module that utilizes most of the other modules implemented.
---
 -- This is an impure module, as GHC is run which requires IO.
 --
 -- Note on (SrcSpan, LHsExpr GhcPs):
@@ -324,8 +323,12 @@ repairAttempt
       zipWith (\(fs, _) r -> (fs, r)) fix_cands
         <$> checkFixes desc (map snd fix_cands)
 
--- TODO: DOCUMENT
--- Returns an empty list when the EExpr list is empty
+-- | Runs a given (changed) Program against the Test-Suite described in ProblemDescription.
+-- The Result is the Test-Suite-Result, where
+-- Right True is full success (the tests exited with 0), Right False is full failure (e.g., timeout or errors in the test-framework)
+-- Left [Bool] expresses a list of the results of each run test, where true is passing and false is failing.
+-- Shortwires an empty list when the EExpr list is empty.
+-- TODO: DOCUMENT (Further)
 checkFixes ::
   ProblemDescription ->
   [EExpr] ->

--- a/src/Endemic/Repair.hs
+++ b/src/Endemic/Repair.hs
@@ -22,9 +22,9 @@ module Endemic.Repair where
 
 import Bag (bagToList, emptyBag, listToBag)
 import Constraint
+import Control.Arrow (first, second)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Monad (when, (>=>))
-import Data.Bifunctor (Bifunctor (first))
 import Data.Char (isAlphaNum)
 import Data.Dynamic (fromDyn)
 import Data.Either (lefts)
@@ -214,7 +214,14 @@ failingProps rc cc ep@EProb {..} = do
 repair :: CompileConfig -> RepairConfig -> EProblem -> IO [EFix]
 repair cc rc prob@EProb {..} = do
   ecfs <- getExprFitCands cc $ noLoc $ HsLet NoExtField e_ctxt $ noLoc undefVar
-  let desc = ProbDesc {progProblem = prob, exprFitCands = ecfs, compConf = cc, repConf = rc}
+  let desc =
+        ProbDesc
+          { progProblem = prob,
+            exprFitCands = ecfs,
+            compConf = cc,
+            repConf = rc,
+            probModule = Nothing
+          }
   map fst . filter (\(_, r) -> r == Right True) <$> repairAttempt desc
 
 -- | Finds the locations in the program that are evaluated by failing tests

--- a/src/Endemic/Repair.hs
+++ b/src/Endemic/Repair.hs
@@ -221,7 +221,7 @@ repair cc rc prob@EProb {..} = do
             repConf = rc,
             probModule = Nothing
           }
-  map fst . filter (\(_, r) -> r == Right True) <$> repairAttempt desc
+  map fst . filter (isFixed . snd) <$> repairAttempt desc
 
 -- | Finds the locations in the program that are evaluated by failing tests
 -- and returns those as programs with holes at that location.
@@ -296,7 +296,7 @@ processFits cc fits = do
 -- As an important sidenote, places that are not in failing properties will not be altered.
 repairAttempt ::
   ProblemDescription ->
-  IO [(EFix, Either [Bool] Bool)]
+  IO [(EFix, TestSuiteResult)]
 repairAttempt
   desc@ProbDesc
     { compConf = cc,
@@ -332,7 +332,7 @@ repairAttempt
 checkFixes ::
   ProblemDescription ->
   [EExpr] ->
-  IO [Either [Bool] Bool]
+  IO [TestSuiteResult]
 checkFixes
   ProbDesc
     { compConf = cc,
@@ -398,7 +398,7 @@ checkFixes
                     std_out = CreatePipe
                   }
             return (hout, ph)
-          waitOnCheck :: (Handle, ProcessHandle) -> IO (Either [Bool] Bool)
+          waitOnCheck :: (Handle, ProcessHandle) -> IO TestSuiteResult
           waitOnCheck (hout, ph) = do
             ec <- timeout timeoutVal $ waitForProcess ph
             case ec of

--- a/src/Endemic/Search.hs
+++ b/src/Endemic/Search.hs
@@ -1,6 +1,7 @@
 module Endemic.Search
   ( module Endemic.Search.Genetic,
     module Endemic.Search.PseudoGenetic,
+    module Endemic.Search.Random,
     module Endemic.Search.Class,
   )
 where
@@ -9,7 +10,9 @@ import Endemic.Configuration (SearchAlgorithm (..))
 import Endemic.Search.Class
 import Endemic.Search.Genetic
 import Endemic.Search.PseudoGenetic
+import Endemic.Search.Random
 
 instance Search SearchAlgorithm where
   runRepair (Genetic c) = runRepair c
   runRepair (PseudoGenetic c) = runRepair c
+  runRepair (Random c) = runRepair c

--- a/src/Endemic/Search.hs
+++ b/src/Endemic/Search.hs
@@ -8,6 +8,7 @@ where
 
 import Endemic.Configuration (SearchAlgorithm (..))
 import Endemic.Search.Class
+import Endemic.Search.Exhaustive
 import Endemic.Search.Genetic
 import Endemic.Search.PseudoGenetic
 import Endemic.Search.Random
@@ -16,3 +17,4 @@ instance Search SearchAlgorithm where
   runRepair (Genetic c) = runRepair c
   runRepair (PseudoGenetic c) = runRepair c
   runRepair (Random c) = runRepair c
+  runRepair (Exhaustive c) = runRepair c

--- a/src/Endemic/Search/Class.hs
+++ b/src/Endemic/Search/Class.hs
@@ -1,3 +1,16 @@
+-- |
+-- Module      : Endemic.Search.Class
+-- Description : Provides a Top-Level Interface for search algorithms
+-- License     : MIT
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- This module defines a TopLevel Class to define Search Algorithms, that is dependent on a (parameterized) Configuration.
+-- The class hence pushes all responsibilities towards the algorithms and enables the rest of the program to use them "plug-and-play".
+-- For example, the Genetic Search provides an interface to runRepair given a GeneticConfiguration. 
+-- All the logic the Genetic Search requires is fully handeled by the genetic repair, including calling functions for fixes etc. 
+-- Towards the higher level functions, all other pieces can use the repair exchangeably and just need a proper setup of the configurations.
+
 module Endemic.Search.Class where
 
 import Data.Set (Set)

--- a/src/Endemic/Search/Exhaustive.hs
+++ b/src/Endemic/Search/Exhaustive.hs
@@ -1,0 +1,13 @@
+module Endemic.Search.Exhaustive
+  ( module Endemic.Search.Exhaustive.Search,
+    module Endemic.Search.Exhaustive.Configuration,
+    module Endemic.Search.Exhaustive,
+  )
+where
+
+import Endemic.Search.Class
+import Endemic.Search.Exhaustive.Configuration
+import Endemic.Search.Exhaustive.Search
+
+instance Search ExhaustiveConf where
+  runRepair = exhaustiveRepair

--- a/src/Endemic/Search/Exhaustive/Configuration.hs
+++ b/src/Endemic/Search/Exhaustive/Configuration.hs
@@ -21,7 +21,9 @@ import GHC.Generics
 data ExhaustiveConf = ExhaustiveConf
   { -- | Exhaustive budget in seconds
     exhSearchBudget :: Int,
+    -- | Whether to exit early on the first results, or to use the full search budget.
     exhStopOnResults :: Bool,
+    -- | How many fixes to check at once
     exhBatchSize :: Int
   }
   deriving (Show, Eq, Generic, Read)

--- a/src/Endemic/Search/Exhaustive/Configuration.hs
+++ b/src/Endemic/Search/Exhaustive/Configuration.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Endemic.Search.Exhaustive.Configuration where
+
+import Data.Default
+import Data.Maybe (fromMaybe)
+import Deriving.Aeson
+import Endemic.Configuration.Materializeable
+import GHC.Generics
+
+--------------------------------------------------------------------------------
+----                      Configuration                                   ------
+--------------------------------------------------------------------------------
+
+data ExhaustiveConf = ExhaustiveConf
+  { -- | Exhaustive budget in seconds
+    exhSearchBudget :: Int,
+    exhIgnoreFailing :: Bool,
+    exhStopOnResults :: Bool
+  }
+  deriving (Show, Eq, Generic, Read)
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[OmitNothingFields, RejectUnknownFields, FieldLabelModifier '[CamelToSnake]] ExhaustiveConf
+
+instance Default ExhaustiveConf where
+  def =
+    ExhaustiveConf
+      { exhSearchBudget = 5 * 60,
+        exhIgnoreFailing = True,
+        exhStopOnResults = False
+      }
+
+instance Materializeable ExhaustiveConf where
+  data Unmaterialized ExhaustiveConf = UmExhaustiveRepairConfiguration
+    { umExhaustiveSearchBudget :: Maybe Int,
+      umExhaustiveStopOnResults :: Maybe Bool,
+      umExhaustiveIgnoreFailing :: Maybe Bool
+    }
+    deriving (Show, Eq, Generic)
+    deriving
+      (FromJSON, ToJSON)
+      via CustomJSON '[OmitNothingFields, RejectUnknownFields, FieldLabelModifier '[StripPrefix "um", CamelToSnake]] (Unmaterialized ExhaustiveConf)
+
+  conjure = UmExhaustiveRepairConfiguration Nothing Nothing Nothing
+
+  override x Nothing = x
+  override ExhaustiveConf {..} (Just UmExhaustiveRepairConfiguration {..}) =
+    ExhaustiveConf
+      { exhSearchBudget = fromMaybe exhSearchBudget umExhaustiveSearchBudget,
+        exhStopOnResults = fromMaybe exhStopOnResults umExhaustiveStopOnResults,
+        exhIgnoreFailing = fromMaybe exhIgnoreFailing umExhaustiveIgnoreFailing
+      }

--- a/src/Endemic/Search/Exhaustive/Configuration.hs
+++ b/src/Endemic/Search/Exhaustive/Configuration.hs
@@ -21,8 +21,8 @@ import GHC.Generics
 data ExhaustiveConf = ExhaustiveConf
   { -- | Exhaustive budget in seconds
     exhSearchBudget :: Int,
-    exhIgnoreFailing :: Bool,
-    exhStopOnResults :: Bool
+    exhStopOnResults :: Bool,
+    exhBatchSize :: Int
   }
   deriving (Show, Eq, Generic, Read)
   deriving
@@ -33,15 +33,15 @@ instance Default ExhaustiveConf where
   def =
     ExhaustiveConf
       { exhSearchBudget = 5 * 60,
-        exhIgnoreFailing = True,
-        exhStopOnResults = False
+        exhStopOnResults = False,
+        exhBatchSize = 10
       }
 
 instance Materializeable ExhaustiveConf where
   data Unmaterialized ExhaustiveConf = UmExhaustiveRepairConfiguration
     { umExhaustiveSearchBudget :: Maybe Int,
       umExhaustiveStopOnResults :: Maybe Bool,
-      umExhaustiveIgnoreFailing :: Maybe Bool
+      umExhaustiveBatchSize :: Maybe Int
     }
     deriving (Show, Eq, Generic)
     deriving
@@ -55,5 +55,5 @@ instance Materializeable ExhaustiveConf where
     ExhaustiveConf
       { exhSearchBudget = fromMaybe exhSearchBudget umExhaustiveSearchBudget,
         exhStopOnResults = fromMaybe exhStopOnResults umExhaustiveStopOnResults,
-        exhIgnoreFailing = fromMaybe exhIgnoreFailing umExhaustiveIgnoreFailing
+        exhBatchSize = fromMaybe exhBatchSize umExhaustiveBatchSize
       }

--- a/src/Endemic/Search/Exhaustive/Search.hs
+++ b/src/Endemic/Search/Exhaustive/Search.hs
@@ -55,12 +55,12 @@ exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
             fixes <-
               Set.fromList . map fst
                 . filter (isFixed . snd)
-                . zip to_check
+                . zip check_list
                 <$> checkFixes desc (map (`replaceExpr` prog_at_ty) check_list)
             if Set.null fixes
               then loop checked' (rest : lvls)
               else do
-                logStr INFO $ "Found fixes after" ++ show (Set.size checked') ++ " checks!"
+                logStr INFO $ "Found fixes after " ++ show (Set.size checked') ++ " checks!"
                 mapM_ (logOut INFO) $ Set.toList fixes
                 if exhStopOnResults
                   then return fixes

--- a/src/Endemic/Search/Exhaustive/Search.hs
+++ b/src/Endemic/Search/Exhaustive/Search.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Endemic.Search.Exhaustive.Search where
+
+import Control.Arrow (first, (***))
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Endemic.Configuration.Types (ProblemDescription (..), (<~))
+import Endemic.Repair (repairAttempt)
+import Endemic.Search.Exhaustive.Configuration (ExhaustiveConf (..), Unmaterialized (umExhaustiveSearchBudget))
+import Endemic.Traversals (replaceExpr)
+import Endemic.Types
+import Endemic.Util
+import System.CPUTime (getCPUTime)
+
+exhaustiveRepair :: ExhaustiveConf -> ProblemDescription -> IO (Set EFix)
+exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
+  start <- getCPUTime
+  -- We use BFS, i.e. check all 1 level fixes, then all 2 level fixes, etc:
+  logStr VERBOSE "Starting exhaustive search!"
+  let loop unfixed = do
+        (fixes, to_check') <- reduce <$> mapM (exhaustiveRepairIter start) unfixed
+        if not (Set.null fixes)
+          then do
+            logStr INFO "Found fixes!"
+            mapM_ (logOut INFO) $ Set.toList fixes
+            if exhStopOnResults
+              then return fixes
+              else Set.union fixes <$> loop to_check'
+          else loop to_check'
+  loop [Map.empty]
+  where
+    reduce :: [(Set EFix, [EFix])] -> (Set EFix, [EFix])
+    reduce = (Set.unions *** List.concat) . unzip
+    ProbDesc {progProblem = EProb {e_prog = start_prog}} = desc
+    exhaustiveRepairIter :: Integer -> EFix -> IO (Set EFix, [EFix])
+    exhaustiveRepairIter start cur_fix = do
+      logOut VERBOSE cur_fix
+      cur_time <- getCPUTime
+      let diff = cur_time - start
+          budget_over = diff >= budgetInPicoSeconds
+      if budget_over
+        then logStr INFO "Time budget done, returning!" >> return (Set.empty, [])
+        else do
+          let to_cur_fix = first (`mergeFixes` cur_fix)
+          all_fixes <-
+            collectStats $
+              map to_cur_fix
+                <$> repairAttempt (desc <~ replaceExpr cur_fix prog_at_ty)
+          let isFixed (Right x) = x
+              isFixed (Left ps) = and ps
+              (fixed, not_fixed) = List.partition (isFixed . snd) all_fixes
+              to_check =
+                map fst $
+                  if exhIgnoreFailing
+                    then List.filter ((/= Right False) . snd) not_fixed
+                    else not_fixed
+              found_fixes = Set.fromList (map fst fixed)
+          return (found_fixes, to_check)
+    EProb {..} = progProblem
+    prog_at_ty = progAtTy e_prog e_ty
+    budgetInPicoSeconds = fromIntegral exhSearchBudget * 1_000_000_000_000

--- a/src/Endemic/Search/Exhaustive/Search.hs
+++ b/src/Endemic/Search/Exhaustive/Search.hs
@@ -9,57 +9,63 @@ import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Endemic.Configuration.Types (ProblemDescription (..), (<~))
-import Endemic.Repair (repairAttempt)
+import Endemic.Repair (checkFixes, repairAttempt)
 import Endemic.Search.Exhaustive.Configuration (ExhaustiveConf (..), Unmaterialized (umExhaustiveSearchBudget))
 import Endemic.Traversals (replaceExpr)
 import Endemic.Types
 import Endemic.Util
 import System.CPUTime (getCPUTime)
 
+lazyAllCombsByLevel :: [EFix] -> [[EFix]]
+lazyAllCombsByLevel fixes = fixes : lacbl' fixes fixes
+  where
+    lacbl' orig cur_level = merged : lacbl' orig merged
+      where
+        merged = orig >>= (flip map cur_level . mergeFixes)
+
 exhaustiveRepair :: ExhaustiveConf -> ProblemDescription -> IO (Set EFix)
 exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
   start <- getCPUTime
   -- We use BFS, i.e. check all 1 level fixes, then all 2 level fixes, etc:
   logStr VERBOSE "Starting exhaustive search!"
-  let loop unfixed = do
-        (fixes, to_check') <- reduce <$> mapM (exhaustiveRepairIter start) unfixed
-        if not (Set.null fixes)
-          then do
-            logStr INFO "Found fixes!"
-            mapM_ (logOut INFO) $ Set.toList fixes
-            if exhStopOnResults
-              then return fixes
-              else Set.union fixes <$> loop to_check'
-          else loop to_check'
-  loop [Map.empty]
+  -- Note: we don't have to recompute the fixes again and again
+  all_fix_combs <- lazyAllCombsByLevel . map fst <$> repairAttempt desc
+  let isFixed (Right x) = x
+      isFixed (Left ps) = and ps
+      loop :: Set EFix -> [[EFix]] -> IO (Set EFix)
+      loop _ [] = return Set.empty
+      loop checked ([] : lvls) = loop checked lvls
+      loop checked (lvl : lvls) = do
+        logOut VERBOSE (length lvl)
+        cur_time <- getCPUTime
+        let diff = cur_time - start
+            budget_over = diff >= budgetInPicoSeconds
+        if budget_over
+          then logStr INFO "Time budget done, returning!" >> return Set.empty
+          else do
+            let (to_check, rest) = List.splitAt exhBatchSize lvl
+                -- Our way of constructing the combinations gives a lot of
+                -- repition, so we can cache tose we've checked already
+                -- to avoid having to check again.
+                not_checked = filter (not . (`Set.member` checked)) to_check
+                checked' = Set.fromList not_checked `Set.union` checked
+            mapM_ (logOut VERBOSE) not_checked
+            fixes <-
+              Set.fromList . map fst
+                . filter (isFixed . snd)
+                . zip to_check
+                <$> checkFixes desc (map (`replaceExpr` prog_at_ty) to_check)
+            if Set.null fixes
+              then loop checked' (rest : lvls)
+              else do
+                logStr INFO $ "Found fixes after" ++ show (Set.size checked') ++ " checks!"
+                mapM_ (logOut INFO) $ Set.toList fixes
+                if exhStopOnResults
+                  then return fixes
+                  else Set.union fixes <$> loop checked' (rest : lvls)
+
+  loop Set.empty all_fix_combs
   where
-    reduce :: [(Set EFix, [EFix])] -> (Set EFix, [EFix])
-    reduce = (Set.unions *** List.concat) . unzip
-    ProbDesc {progProblem = EProb {e_prog = start_prog}} = desc
-    exhaustiveRepairIter :: Integer -> EFix -> IO (Set EFix, [EFix])
-    exhaustiveRepairIter start cur_fix = do
-      logOut VERBOSE cur_fix
-      cur_time <- getCPUTime
-      let diff = cur_time - start
-          budget_over = diff >= budgetInPicoSeconds
-      if budget_over
-        then logStr INFO "Time budget done, returning!" >> return (Set.empty, [])
-        else do
-          let to_cur_fix = first (`mergeFixes` cur_fix)
-          all_fixes <-
-            collectStats $
-              map to_cur_fix
-                <$> repairAttempt (desc <~ replaceExpr cur_fix prog_at_ty)
-          let isFixed (Right x) = x
-              isFixed (Left ps) = and ps
-              (fixed, not_fixed) = List.partition (isFixed . snd) all_fixes
-              to_check =
-                map fst $
-                  if exhIgnoreFailing
-                    then List.filter ((/= Right False) . snd) not_fixed
-                    else not_fixed
-              found_fixes = Set.fromList (map fst fixed)
-          return (found_fixes, to_check)
     EProb {..} = progProblem
     prog_at_ty = progAtTy e_prog e_ty
     budgetInPicoSeconds = fromIntegral exhSearchBudget * 1_000_000_000_000

--- a/src/Endemic/Search/Exhaustive/Search.hs
+++ b/src/Endemic/Search/Exhaustive/Search.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
+
 -- |
 -- Module      : Endemic.Search.Exhaustive.Search
 -- Description : Provides an Exhaustive Search Algorithm based on typed holes.
@@ -9,8 +10,8 @@
 --
 -- This module provides a simple exhaustive search algorithm.
 -- For Pseudocode see "exhaustiveRepair".
--- 
--- Exhaustive Search is expected to perform well for small programs, 
+--
+-- Exhaustive Search is expected to perform well for small programs,
 -- with bigger programs it's a bit of luck whether you happen to visit the relevant parts first.
 module Endemic.Search.Exhaustive.Search where
 
@@ -27,10 +28,10 @@ import Endemic.Types
 import Endemic.Util
 import System.CPUTime (getCPUTime)
 
--- | Tries to repair a program by exhaustively replacing all elements with holes, 
--- Then checking all possible replacements for the hole. 
--- After all expressions have been replaced by holes and their respective hole-fits, 
--- the program is similiarly tried to be fixed with two-holes-at-once. 
+-- | Tries to repair a program by exhaustively replacing all elements with holes,
+-- Then checking all possible replacements for the hole.
+-- After all expressions have been replaced by holes and their respective hole-fits,
+-- the program is similiarly tried to be fixed with two-holes-at-once.
 -- This procedure is repeated until a time-budget is over.
 exhaustiveRepair :: ExhaustiveConf -> ProblemDescription -> IO (Set EFix)
 exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
@@ -39,9 +40,7 @@ exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
   logStr VERBOSE "Starting exhaustive search!"
   -- Note: we don't have to recompute the fixes again and again
   all_fix_combs <- lazyAllCombsByLevel . map fst <$> repairAttempt desc
-  let isFixed (Right x) = x
-      isFixed (Left ps) = and ps
-      loop :: Set EFix -> [[EFix]] -> IO (Set EFix)
+  let loop :: Set EFix -> [[EFix]] -> IO (Set EFix)
       loop _ [] = return Set.empty
       loop checked ([] : lvls) = loop checked lvls
       loop checked (lvl : lvls) = do
@@ -83,7 +82,7 @@ exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
 
 -- | Provides all combinations of fixes, for a given level, in a lazy way.
 -- Crucial, as otherwise all Fixes would need to be computed pre-emptively, making an iterative search nearly impossible.
---   
+--
 -- "Finally, some lazy evaluation magic!"
 lazyAllCombsByLevel :: [EFix] -> [[EFix]]
 lazyAllCombsByLevel fixes = fixes : lacbl' fixes fixes
@@ -91,4 +90,3 @@ lazyAllCombsByLevel fixes = fixes : lacbl' fixes fixes
     lacbl' orig cur_level = merged : lacbl' orig merged
       where
         merged = orig >>= (flip map cur_level . mergeFixes)
-

--- a/src/Endemic/Search/Exhaustive/Search.hs
+++ b/src/Endemic/Search/Exhaustive/Search.hs
@@ -16,6 +16,7 @@ import Endemic.Types
 import Endemic.Util
 import System.CPUTime (getCPUTime)
 
+-- | Finally, some lazy evaluation magic!
 lazyAllCombsByLevel :: [EFix] -> [[EFix]]
 lazyAllCombsByLevel fixes = fixes : lacbl' fixes fixes
   where
@@ -47,14 +48,15 @@ exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
                 -- Our way of constructing the combinations gives a lot of
                 -- repition, so we can cache tose we've checked already
                 -- to avoid having to check again.
-                not_checked = filter (not . (`Set.member` checked)) to_check
-                checked' = Set.fromList not_checked `Set.union` checked
-            mapM_ (logOut VERBOSE) not_checked
+                not_checked = Set.fromList $ filter (not . (`Set.member` checked)) to_check
+                checked' = not_checked `Set.union` checked
+                check_list = Set.toList not_checked
+            mapM_ (logOut VERBOSE) check_list
             fixes <-
               Set.fromList . map fst
                 . filter (isFixed . snd)
                 . zip to_check
-                <$> checkFixes desc (map (`replaceExpr` prog_at_ty) to_check)
+                <$> checkFixes desc (map (`replaceExpr` prog_at_ty) check_list)
             if Set.null fixes
               then loop checked' (rest : lvls)
               else do

--- a/src/Endemic/Search/Genetic/Configuration.hs
+++ b/src/Endemic/Search/Genetic/Configuration.hs
@@ -31,7 +31,7 @@ data GeneticConfiguration = GConf
     -- | How many Chromosomes are in one Population. In case of Island Evolution, each Island will have this population.
     populationSize :: Int,
     -- | How long the process should run (in Minutes)
-    timeoutInMinutes :: Double,
+    timeoutInSeconds :: Double,
     -- | Whether or not to stop at the generation that first produces positive results
     stopOnResults :: Bool,
     -- | Nothing to not do Tournament Selection, existing Conf will use Tournament instead (See below for more info)
@@ -60,7 +60,7 @@ instance Default GeneticConfiguration where
       crossoverRate = 0.4
       iterations = 50
       populationSize = 64
-      timeoutInMinutes = 5
+      timeoutInSeconds = 5 * 60
       stopOnResults = True
       tournamentConfiguration = Nothing
       islandConfiguration = Nothing
@@ -78,7 +78,7 @@ instance Materializeable GeneticConfiguration where
       umCrossoverRate :: Maybe Double,
       umIterations :: Maybe Int,
       umPopulationSize :: Maybe Int,
-      umTimeoutInMinutes :: Maybe Double,
+      umTimeoutInSeconds :: Maybe Double,
       umStopOnResults :: Maybe Bool,
       umTournamentConfiguration :: Maybe (Unmaterialized TournamentConfiguration),
       umIslandConfiguration :: Maybe (Unmaterialized IslandConfiguration),
@@ -108,7 +108,7 @@ instance Materializeable GeneticConfiguration where
         crossoverRate = fromMaybe crossoverRate umCrossoverRate,
         iterations = fromMaybe iterations umIterations,
         populationSize = fromMaybe populationSize umPopulationSize,
-        timeoutInMinutes = fromMaybe timeoutInMinutes umTimeoutInMinutes,
+        timeoutInSeconds = fromMaybe timeoutInSeconds umTimeoutInSeconds,
         stopOnResults = fromMaybe stopOnResults umStopOnResults,
         dropRate = fromMaybe dropRate umDropRate,
         tryMinimizeFixes = fromMaybe tryMinimizeFixes umTryMinimizeFixes,

--- a/src/Endemic/Search/Genetic/GenMonad.hs
+++ b/src/Endemic/Search/Genetic/GenMonad.hs
@@ -24,7 +24,7 @@ import Endemic.Search.Genetic.Configuration
 import Endemic.Search.Genetic.Types
 import Endemic.Search.Genetic.Utils
 import Endemic.Traversals (replaceExpr)
-import Endemic.Types (EFix, EProblem (..))
+import Endemic.Types (EFix, EProblem (..), TestSuiteResult)
 import Endemic.Util (collectStats, mergeFixes, mergeFixes', progAtTy)
 import GHC (GhcPs, HsExpr, SrcSpan, isSubspanOf)
 import GhcPlugins (Outputable (..), liftIO, ppr, showSDocUnsafe)
@@ -140,7 +140,7 @@ instance Chromosome EFix where
 
 -- | Calculates the fitness of an EFix by checking it's FixResults (=The Results of the property-tests).
 -- It is intended to be cached using the Fitness Cache in the GenMonad.
-basicFitness :: EFix -> Either [Bool] Bool -> Double
+basicFitness :: EFix -> TestSuiteResult -> Double
 basicFitness mf fix_res =
   case fix_res of
     Left bools -> 1 - fitness_func (mf, bools) / fromIntegral (length bools)

--- a/src/Endemic/Search/Genetic/Search.hs
+++ b/src/Endemic/Search/Genetic/Search.hs
@@ -30,7 +30,7 @@ import GhcPlugins (liftIO)
 -- This is the primary method of this module.
 -- It runs a genetic search that terminates in three cases:
 --     a) x iterations done
---     b) n minutes passed
+--     b) n seconds passed
 --     c) solutions found (optionally with early exit)
 -- It will return an empty List in case of no found solutions.
 --

--- a/src/Endemic/Search/Genetic/Utils.hs
+++ b/src/Endemic/Search/Genetic/Utils.hs
@@ -19,7 +19,7 @@ import System.Random (Random (randomR), RandomGen, uniformR)
 
 -- | Reads the timeOutInMinutes of a configuration and rounds it to the nearest ms
 maxTimeInMS :: GeneticConfiguration -> Int
-maxTimeInMS conf = round $ 1000 * 60 * timeoutInMinutes conf
+maxTimeInMS conf = round $ 1000 * timeoutInSeconds conf
 
 -- | removes a given pair from a List, e.g.
 -- > removePairFromList [2,7,12,5,1] (1,2)

--- a/src/Endemic/Search/PseudoGenetic/Search.hs
+++ b/src/Endemic/Search/PseudoGenetic/Search.hs
@@ -125,7 +125,7 @@ pseudoGeneticRepair
             runGen (fix, _) = do
               let n_prog = replaceExpr fix prog_at_ty
               map (\(f, r) -> (f `mergeFixes` fix, r))
-                <$> collectStats (repairAttempt (desc ~> n_prog))
+                <$> collectStats (repairAttempt (desc <~ n_prog))
             loop :: [(EFix, Either [Bool] Bool)] -> Int -> IO (Set EFix)
             loop gen n
               | not (null $ successful gen) =

--- a/src/Endemic/Search/PseudoGenetic/Search.hs
+++ b/src/Endemic/Search/PseudoGenetic/Search.hs
@@ -51,7 +51,7 @@ fitness = fromIntegral . length . filter id . snd
 complementary :: PseudoGenConf -> Individual -> Individual -> Float
 complementary gc a b = avg $ map fitness $ crossover gc a b
 
-individuals :: [(EFix, Either [Bool] Bool)] -> [Individual]
+individuals :: [(EFix, TestSuiteResult)] -> [Individual]
 individuals = mapMaybe fromHelpful
   where
     fromHelpful (fs, Left r) | or r = Just (fs, r)
@@ -79,8 +79,8 @@ pruneGeneration PseudoGenConf {..} new_gen =
     isFit _ = Nothing
 
 -- | Checks a given fix-result for successfulness, that is passing all tests.
-successful :: Eq b => [(a, Either b Bool)] -> [(a, Either b Bool)]
-successful = filter (\(_, r) -> r == Right True)
+successful :: [(a, TestSuiteResult)] -> [(a, TestSuiteResult)]
+successful = filter (isFixed . snd)
 
 -- |
 --   This method combines individuals by merging their fixes.
@@ -126,7 +126,7 @@ pseudoGeneticRepair
               let n_prog = replaceExpr fix prog_at_ty
               map (\(f, r) -> (f `mergeFixes` fix, r))
                 <$> collectStats (repairAttempt (desc <~ n_prog))
-            loop :: [(EFix, Either [Bool] Bool)] -> Int -> IO (Set EFix)
+            loop :: [(EFix, TestSuiteResult)] -> Int -> IO (Set EFix)
             loop gen n
               | not (null $ successful gen) =
                 do

--- a/src/Endemic/Search/PseudoGenetic/Search.hs
+++ b/src/Endemic/Search/PseudoGenetic/Search.hs
@@ -125,7 +125,7 @@ pseudoGeneticRepair
             runGen (fix, _) = do
               let n_prog = replaceExpr fix prog_at_ty
               map (\(f, r) -> (f `mergeFixes` fix, r))
-                <$> collectStats (repairAttempt (desc `setProg` n_prog))
+                <$> collectStats (repairAttempt (desc ~> n_prog))
             loop :: [(EFix, Either [Bool] Bool)] -> Int -> IO (Set EFix)
             loop gen n
               | not (null $ successful gen) =
@@ -164,13 +164,3 @@ deDupOn f as = map snd $ filter ((`Set.member` grouped) . fst) zas
     zas = zip [(0 :: Int) ..] as
     zbs = zip [(0 :: Int) ..] $ map f as
     grouped = Set.fromList $ map (fst . head) $ groupBy ((==) `on` snd) $ sortOn snd zbs
-
--- | Merging fix-candidates is mostly applying the list of changes in order.
---   The only addressed special case is to discard the next change,
---   if the next change is also used at the same place in the second fix.
-mergeFixes :: EFix -> EFix -> EFix
-mergeFixes f1 f2 = Map.fromList $ mf' (Map.toList f1) (Map.toList f2)
-  where
-    mf' [] xs = xs
-    mf' xs [] = xs
-    mf' (x : xs) ys = x : mf' xs (filter (not . isSubspanOf (fst x) . fst) ys)

--- a/src/Endemic/Search/PseudoGenetic/Search.hs
+++ b/src/Endemic/Search/PseudoGenetic/Search.hs
@@ -111,13 +111,13 @@ selection gc indivs = pure $ pruneGeneration gc de_duped
 pseudoGeneticRepair :: PseudoGenConf -> ProblemDescription -> IO (Set EFix)
 pseudoGeneticRepair
   gc@PseudoGenConf {..}
-  ProbDesc
+  desc@ProbDesc
     { compConf = cc,
       repConf = rc,
       progProblem = prob@EProb {..},
       exprFitCands = efcs
     } = do
-    first_attempt <- collectStats $ repairAttempt cc rc prob (Just efcs)
+    first_attempt <- collectStats $ repairAttempt desc
     if not $ null $ successful first_attempt
       then return (Set.fromList $ map fst $ successful first_attempt)
       else do
@@ -125,7 +125,7 @@ pseudoGeneticRepair
             runGen (fix, _) = do
               let n_prog = replaceExpr fix prog_at_ty
               map (\(f, r) -> (f `mergeFixes` fix, r))
-                <$> collectStats (repairAttempt cc rc prob {e_prog = n_prog} (Just efcs))
+                <$> collectStats (repairAttempt (desc `setProg` n_prog))
             loop :: [(EFix, Either [Bool] Bool)] -> Int -> IO (Set EFix)
             loop gen n
               | not (null $ successful gen) =

--- a/src/Endemic/Search/Random.hs
+++ b/src/Endemic/Search/Random.hs
@@ -1,0 +1,13 @@
+module Endemic.Search.Random
+  ( module Endemic.Search.Random.Search,
+    module Endemic.Search.Random.Configuration,
+    module Endemic.Search.Random,
+  )
+where
+
+import Endemic.Search.Class
+import Endemic.Search.Random.Configuration
+import Endemic.Search.Random.Search
+
+instance Search RandomConf where
+  runRepair = randomRepair

--- a/src/Endemic/Search/Random/Configuration.hs
+++ b/src/Endemic/Search/Random/Configuration.hs
@@ -21,8 +21,11 @@ import GHC.Generics
 data RandomConf = RandConf
   { -- | Random budget in seconds
     randSearchBudget :: Int,
+    -- | The maximum number of holes that will be tried for a single attempt. Limits the fixsize to [1,randMaxFixSize]
     randMaxFixSize :: Int,
+    -- | Whether or not we consider failing or non-terminating programs as (potentially valid) fixes. False for skipping them, True for trying them.
     randIgnoreFailing :: Bool,
+    -- | Whether to stop the search on the first result, or to exhaust the search budget
     randStopOnResults :: Bool
   }
   deriving (Show, Eq, Generic, Read)

--- a/src/Endemic/Search/Random/Configuration.hs
+++ b/src/Endemic/Search/Random/Configuration.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Endemic.Search.Random.Configuration where
+
+import Data.Default
+import Data.Maybe (fromMaybe)
+import Deriving.Aeson
+import Endemic.Configuration.Materializeable
+import GHC.Generics
+
+--------------------------------------------------------------------------------
+----                      Configuration                                   ------
+--------------------------------------------------------------------------------
+
+data RandomConf = RandConf
+  { -- | Random budget in seconds
+    randSearchBudget :: Int
+  }
+  deriving (Show, Eq, Generic, Read)
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[OmitNothingFields, RejectUnknownFields, FieldLabelModifier '[CamelToSnake]] RandomConf
+
+instance Default RandomConf where
+  def = RandConf {randSearchBudget = 5 * 60}
+
+instance Materializeable RandomConf where
+  data Unmaterialized RandomConf = UmRandomRepairConfiguration
+    { umRandSearchBudget :: Maybe Int
+    }
+    deriving (Show, Eq, Generic)
+    deriving
+      (FromJSON, ToJSON)
+      via CustomJSON '[OmitNothingFields, RejectUnknownFields, FieldLabelModifier '[StripPrefix "um", CamelToSnake]] (Unmaterialized RandomConf)
+
+  conjure = UmRandomRepairConfiguration Nothing
+
+  override x Nothing = x
+  override RandConf {..} (Just UmRandomRepairConfiguration {..}) =
+    RandConf
+      { randSearchBudget = fromMaybe randSearchBudget umRandSearchBudget
+      }

--- a/src/Endemic/Search/Random/Search.hs
+++ b/src/Endemic/Search/Random/Search.hs
@@ -1,6 +1,18 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
-
+-- |
+-- Module      : Endemic.Search.Random.Search
+-- Description : Provides an Random Search Algorithm based on typed holes.
+-- License     : MIT
+-- Stability   : experimental
+-- Portability : POSIX
+--
+-- This module provides a simple random search algorithm.
+-- For Pseudocode see "randomRepair".
+-- 
+-- Random Search sometimes performs suprisingly well, see https://dl.acm.org/doi/abs/10.1145/2568225.2568254. 
+-- We use it mostly to justify the use of Genetic algorithms, as random search is a good baseline to show that genetic search actually yields benefits. 
+-- Nevertheless, it might be faster as it is low on ritual and for easy problems, or simply by luck, it can find solutions faster.
 module Endemic.Search.Random.Search where
 
 import Control.Arrow (first)
@@ -16,6 +28,17 @@ import Endemic.Util
 import System.CPUTime (getCPUTime)
 import System.Random.SplitMix (SMGen, mkSMGen, nextInteger)
 
+-- | Tries to repair a program by randomly punching holes and trying random replacements.
+-- 
+-- Pseudocode:
+-- While SearchBudget Left 
+--    pick random number N between [1,maxFixSize]
+--    punch N holes in the Program 
+--    fill every hole with a random fix
+--    if Fix-Not-Seen
+--      Check fix
+--      Add Fix either to Results or Seen-Fixes
+--    Update Timer 
 randomRepair :: RandomConf -> ProblemDescription -> IO (Set EFix)
 randomRepair r@RandConf {..} desc@ProbDesc {..} = do
   logStr VERBOSE "Starting random search!"
@@ -56,7 +79,7 @@ randomRepair r@RandConf {..} desc@ProbDesc {..} = do
 
           let keep_going = randomRepair' start gen'' complete_fix
               done = do
-                logStr INFO "Fix found!"
+                logStr INFO "Fix found in Random Search!"
                 logOut INFO complete_fix
                 logOut DEBUG fixed_prog
                 if randStopOnResults

--- a/src/Endemic/Search/Random/Search.hs
+++ b/src/Endemic/Search/Random/Search.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Endemic.Search.Random.Search where
+
+import Control.Arrow (first)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Endemic.Configuration (ProblemDescription (..), newSeed, (~>))
+import Endemic.Eval
+import Endemic.Repair (checkFixes, findEvaluatedHoles, getHoleFits, processFits, replacements)
+import Endemic.Search.Random.Configuration (RandomConf (..))
+import Endemic.Traversals (replaceExpr)
+import Endemic.Types
+import Endemic.Util
+import GHC (HsExpr (..), NoExtField (NoExtField))
+import GhcPlugins
+import System.CPUTime (getCPUTime)
+import System.Random.SplitMix (SMGen, mkSMGen, nextInteger)
+
+randomRepair :: RandomConf -> ProblemDescription -> IO (Set EFix)
+randomRepair r@RandConf {..} desc@ProbDesc {..} = do
+  start <- liftIO getCPUTime
+  seed <- newSeed
+  randomRepair' start (mkSMGen $ fromIntegral seed) Map.empty
+  where
+    randomRepair' :: Integer -> SMGen -> EFix -> IO (Set EFix)
+    randomRepair' start gen fix_so_far = do
+      cur_time <- getCPUTime
+      let diff = cur_time - start
+      -- CPUTime is in picoseconds
+      if diff >= fromIntegral randSearchBudget * 1_000_000_000_000
+        then do
+          logStr INFO "Time budget done, returning!"
+          return Set.empty
+        else do
+          let prog' = replaceExpr fix_so_far prog_at_ty
+          hole_cands <- findEvaluatedHoles (desc ~> prog')
+          let (r_hole_ind, gen') = nextInteger 0 (fromIntegral (length hole_cands - 1)) gen
+              chosen_hole = hole_cands !! fromIntegral r_hole_ind
+          -- We get a  list of list of fits. However, we assume that there are
+          -- no other holes in the program
+          [fits] <- getHoleFits compConf exprFitCands [chosen_hole] >>= processFits compConf
+          let fix_cands :: [(EFix, EExpr)]
+              fix_cands = map (first Map.fromList) $ replacements chosen_hole fits
+              (r_fix_ind, gen'') = nextInteger 0 (fromIntegral (length fix_cands - 1)) gen'
+              (chosen_fix, fixed_prog) = fix_cands !! fromIntegral r_fix_ind
+              complete_fix = mergeFixes fix_so_far chosen_fix
+
+          [check_res] <- checkFixes desc [fixed_prog]
+
+          let keep_going = randomRepair' start gen'' complete_fix
+              done =
+                do
+                  logStr INFO "Fix found!"
+                  logOut INFO complete_fix
+                  Set.insert complete_fix <$> randomRepair' start gen'' Map.empty
+
+          case check_res of
+            Right True -> done
+            Right False -> keep_going
+            Left res ->
+              if and res
+                then done
+                else keep_going
+
+    efcs = Just exprFitCands
+    EProb {..} = progProblem
+    prog_at_ty = progAtTy e_prog e_ty

--- a/src/Endemic/Search/Random/Search.hs
+++ b/src/Endemic/Search/Random/Search.hs
@@ -4,26 +4,22 @@
 module Endemic.Search.Random.Search where
 
 import Control.Arrow (first)
-import Data.Map (Map)
 import qualified Data.Map as Map
-import qualified Data.Map.Merge.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Endemic.Configuration
-import Endemic.Eval
 import Endemic.Repair (checkFixes, findEvaluatedHoles, getHoleFits, processFits, repairAttempt, replacements)
 import Endemic.Search.Random.Configuration (RandomConf (..))
 import Endemic.Traversals (replaceExpr)
 import Endemic.Types
 import Endemic.Util
-import GHC (HsExpr (..), NoExtField (NoExtField))
-import GhcPlugins
 import System.CPUTime (getCPUTime)
 import System.Random.SplitMix (SMGen, mkSMGen, nextInteger)
 
 randomRepair :: RandomConf -> ProblemDescription -> IO (Set EFix)
 randomRepair r@RandConf {..} desc@ProbDesc {..} = do
-  start <- liftIO getCPUTime
+  logStr VERBOSE "Starting random search!"
+  start <- getCPUTime
   seed <- newSeed
   randomRepair' start (mkSMGen $ fromIntegral seed) Map.empty
   where

--- a/src/Endemic/Search/Random/Search.hs
+++ b/src/Endemic/Search/Random/Search.hs
@@ -9,7 +9,7 @@ import qualified Data.Map as Map
 import qualified Data.Map.Merge.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Endemic.Configuration (ProblemDescription (..), newSeed, (~>))
+import Endemic.Configuration
 import Endemic.Eval
 import Endemic.Repair (checkFixes, findEvaluatedHoles, getHoleFits, processFits, repairAttempt, replacements)
 import Endemic.Search.Random.Configuration (RandomConf (..))
@@ -43,7 +43,7 @@ randomRepair r@RandConf {..} desc@ProbDesc {..} = do
               randomRepair' start gen Map.empty
         else do
           let prog' = replaceExpr fix_so_far prog_at_ty
-          hole_cands <- collectStats $ findEvaluatedHoles (desc ~> prog')
+          hole_cands <- collectStats $ findEvaluatedHoles (desc <~ prog')
           let (r_hole_ind, gen') = nextInteger 0 (fromIntegral (length hole_cands - 1)) gen
               chosen_hole = hole_cands !! fromIntegral r_hole_ind
           -- We get a  list of list of fits. However, we assume that there are

--- a/src/Endemic/Search/Random/Search.hs
+++ b/src/Endemic/Search/Random/Search.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
+
 -- |
 -- Module      : Endemic.Search.Random.Search
 -- Description : Provides an Random Search Algorithm based on typed holes.
@@ -9,9 +10,9 @@
 --
 -- This module provides a simple random search algorithm.
 -- For Pseudocode see "randomRepair".
--- 
--- Random Search sometimes performs suprisingly well, see https://dl.acm.org/doi/abs/10.1145/2568225.2568254. 
--- We use it mostly to justify the use of Genetic algorithms, as random search is a good baseline to show that genetic search actually yields benefits. 
+--
+-- Random Search sometimes performs suprisingly well, see https://dl.acm.org/doi/abs/10.1145/2568225.2568254.
+-- We use it mostly to justify the use of Genetic algorithms, as random search is a good baseline to show that genetic search actually yields benefits.
 -- Nevertheless, it might be faster as it is low on ritual and for easy problems, or simply by luck, it can find solutions faster.
 module Endemic.Search.Random.Search where
 
@@ -29,16 +30,16 @@ import System.CPUTime (getCPUTime)
 import System.Random.SplitMix (SMGen, mkSMGen, nextInteger)
 
 -- | Tries to repair a program by randomly punching holes and trying random replacements.
--- 
+--
 -- Pseudocode:
--- While SearchBudget Left 
+-- While SearchBudget Left
 --    pick random number N between [1,maxFixSize]
---    punch N holes in the Program 
+--    punch N holes in the Program
 --    fill every hole with a random fix
 --    if Fix-Not-Seen
 --      Check fix
 --      Add Fix either to Results or Seen-Fixes
---    Update Timer 
+--    Update Timer
 randomRepair :: RandomConf -> ProblemDescription -> IO (Set EFix)
 randomRepair r@RandConf {..} desc@ProbDesc {..} = do
   logStr VERBOSE "Starting random search!"
@@ -88,13 +89,12 @@ randomRepair r@RandConf {..} desc@ProbDesc {..} = do
               try_again = randomRepair' start gen'' fix_so_far
 
           case check_res of
-            Right True -> done
             -- We might want to avoid programs that timeout or fail for some reason.
             Right False ->
               if randIgnoreFailing
                 then try_again
                 else keep_going
-            Left res -> if and res then done else keep_going
+            res -> if isFixed res then done else keep_going
 
     efcs = Just exprFitCands
     EProb {..} = progProblem

--- a/src/Endemic/Search/Random/Search.hs
+++ b/src/Endemic/Search/Random/Search.hs
@@ -6,11 +6,12 @@ module Endemic.Search.Random.Search where
 import Control.Arrow (first)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Map.Merge.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Endemic.Configuration (ProblemDescription (..), newSeed, (~>))
 import Endemic.Eval
-import Endemic.Repair (checkFixes, findEvaluatedHoles, getHoleFits, processFits, replacements)
+import Endemic.Repair (checkFixes, findEvaluatedHoles, getHoleFits, processFits, repairAttempt, replacements)
 import Endemic.Search.Random.Configuration (RandomConf (..))
 import Endemic.Traversals (replaceExpr)
 import Endemic.Types
@@ -28,44 +29,55 @@ randomRepair r@RandConf {..} desc@ProbDesc {..} = do
   where
     randomRepair' :: Integer -> SMGen -> EFix -> IO (Set EFix)
     randomRepair' start gen fix_so_far = do
+      logOut VERBOSE fix_so_far
       cur_time <- getCPUTime
       let diff = cur_time - start
-      -- CPUTime is in picoseconds
-      if diff >= fromIntegral randSearchBudget * 1_000_000_000_000
-        then do
-          logStr INFO "Time budget done, returning!"
-          return Set.empty
+          budget_over = diff >= budgetInPicoSeconds
+          fix_too_big = Map.size fix_so_far >= randMaxFixSize
+      if budget_over || fix_too_big
+        then
+          if budget_over
+            then logStr INFO "Time budget done, returning!" >> return Set.empty
+            else do
+              logStr INFO "Fix got too big, starting over!"
+              randomRepair' start gen Map.empty
         else do
           let prog' = replaceExpr fix_so_far prog_at_ty
-          hole_cands <- findEvaluatedHoles (desc ~> prog')
+          hole_cands <- collectStats $ findEvaluatedHoles (desc ~> prog')
           let (r_hole_ind, gen') = nextInteger 0 (fromIntegral (length hole_cands - 1)) gen
               chosen_hole = hole_cands !! fromIntegral r_hole_ind
           -- We get a  list of list of fits. However, we assume that there are
           -- no other holes in the program
-          [fits] <- getHoleFits compConf exprFitCands [chosen_hole] >>= processFits compConf
+          -- TODO: Where are the "<interactive>" coming from?
+          [fits] <- collectStats $ getHoleFits compConf exprFitCands [chosen_hole] >>= processFits compConf
           let fix_cands :: [(EFix, EExpr)]
               fix_cands = map (first Map.fromList) $ replacements chosen_hole fits
               (r_fix_ind, gen'') = nextInteger 0 (fromIntegral (length fix_cands - 1)) gen'
               (chosen_fix, fixed_prog) = fix_cands !! fromIntegral r_fix_ind
-              complete_fix = mergeFixes fix_so_far chosen_fix
-
-          [check_res] <- checkFixes desc [fixed_prog]
+              -- We have to make sure that the chosen_fix takes precedence.
+              complete_fix = mergeFixes chosen_fix fix_so_far
+          [check_res] <- collectStats $ checkFixes desc [fixed_prog]
 
           let keep_going = randomRepair' start gen'' complete_fix
-              done =
-                do
-                  logStr INFO "Fix found!"
-                  logOut INFO complete_fix
-                  Set.insert complete_fix <$> randomRepair' start gen'' Map.empty
+              done = do
+                logStr INFO "Fix found!"
+                logOut INFO complete_fix
+                logOut DEBUG fixed_prog
+                if randStopOnResults
+                  then return $ Set.singleton complete_fix
+                  else Set.insert complete_fix <$> randomRepair' start gen'' Map.empty
+              try_again = randomRepair' start gen'' fix_so_far
 
           case check_res of
             Right True -> done
-            Right False -> keep_going
-            Left res ->
-              if and res
-                then done
+            -- We might want to avoid programs that timeout or fail for some reason.
+            Right False ->
+              if randIgnoreFailing
+                then try_again
                 else keep_going
+            Left res -> if and res then done else keep_going
 
     efcs = Just exprFitCands
     EProb {..} = progProblem
     prog_at_ty = progAtTy e_prog e_ty
+    budgetInPicoSeconds = fromIntegral randSearchBudget * 1_000_000_000_000

--- a/src/Endemic/Types.hs
+++ b/src/Endemic/Types.hs
@@ -66,6 +66,17 @@ type EType = LHsSigWcType GhcPs
 
 type EExpr = LHsExpr GhcPs
 
+-- | A Result from running a check.
+-- +  Right True means all the checks were satisfied,
+-- +  Right False is full failure (e.g., timeout or errors in the test-framework), and
+-- + Left [Bool] expresses a list of the results of each run test,
+--    where True is passing and False is failing.
+type TestSuiteResult = Either [Bool] Bool
+
+isFixed :: TestSuiteResult -> Bool
+isFixed (Right x) = True
+isFixed (Left xs) = and xs
+
 -- | A fix is a list of replacements and their locations
 type EFix = Map SrcSpan (HsExpr GhcPs)
 

--- a/src/Endemic/Util.hs
+++ b/src/Endemic/Util.hs
@@ -5,6 +5,7 @@
 -- Description : Contains general and other orphaned functions of Endemic
 -- License     : MIT
 -- Stability   : experimental
+--
 -- Your everyday Util file.
 -- Most of the functions contained are about logging.
 -- This is a pure module.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -180,10 +180,7 @@ main = do
       logStr INFO "REPAIRING..."
       seed <- newSeed
       desc <- describeProblem conf target
-      (t, fixes) <- time $
-        case searchAlgorithm of
-          Genetic gconf -> runGenMonad gconf desc seed geneticSearchPlusPostprocessing
-          PseudoGenetic pgc -> pseudoGeneticRepair pgc desc
+      (t, fixes) <- time $ runRepair searchAlgorithm desc
       let newProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
           fbs = map getFixBinds newProgs
           prettyPrinted = map (concatMap ppDiff . snd . applyFixes modul) fbs

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -14,6 +14,7 @@ import Endemic.Configuration
 import Endemic.Diff (applyFixes, fixesToDiffs, getFixBinds, ppDiff)
 import Endemic.Eval
 import Endemic.Search
+import Endemic.Search.Exhaustive
 import Endemic.Search.PseudoGenetic (pseudoGeneticRepair)
 import Endemic.Traversals
 import Endemic.Types
@@ -27,7 +28,12 @@ tests :: TestTree
 tests =
   testGroup
     "Tests"
-    [tastyFixTests, randTests, properGenTests, genTests]
+    [ tastyFixTests,
+      randTests,
+      properGenTests,
+      genTests,
+      exhaustiveTests
+    ]
 
 -- | Chosen fairly by Random.org
 tESTSEED :: Int
@@ -96,6 +102,36 @@ randTests =
                   "@@ -7,1 +7,1 @@ x = 2",
                   "-x = 2",
                   "+x = 3"
+                ]
+              ]
+    ]
+
+exhaustiveTests :: TestTree
+exhaustiveTests =
+  testGroup
+    "Exhaustive search tests"
+    [ let conf = Exhaustive def {exhStopOnResults = True, exhIgnoreFailing = True}
+       in mkSearchTest conf 60_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs" $
+            map
+              unlines
+              [ [ "diff --git a/tests/cases/TastyFix.hs b/tests/cases/TastyFix.hs",
+                  "--- a/tests/cases/TastyFix.hs",
+                  "+++ b/tests/cases/TastyFix.hs",
+                  "@@ -7,1 +7,1 @@ x = 2",
+                  "-x = 2",
+                  "+x = 3"
+                ]
+              ],
+      let conf = Exhaustive def {exhStopOnResults = True, exhIgnoreFailing = True}
+       in mkSearchTest conf 180_000_000 "Repair TwoFixes" "tests/cases/TwoFixes.hs" $
+            map
+              unlines
+              [ [ "diff --git a/tests/cases/TwoFixes.hs b/tests/cases/TwoFixes.hs",
+                  "--- a/tests/cases/TwoFixes.hs",
+                  "+++ b/tests/cases/TwoFixes.hs",
+                  "@@ -12,1 +12,1 @@ brokenPair = (1, 2)",
+                  "-brokenPair = (1, 2)",
+                  "+brokenPair = (3, 4)"
                 ]
               ]
     ]

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -7,10 +7,11 @@ module Main where
 import Data.Default
 import Data.IORef (readIORef)
 import Data.Maybe (isJust, mapMaybe)
+import Data.Set (Set)
 import qualified Data.Set as Set
 import Endemic (getExprFitCands)
 import Endemic.Configuration
-import Endemic.Diff (applyFixes, getFixBinds, ppDiff)
+import Endemic.Diff (applyFixes, fixesToDiffs, getFixBinds, ppDiff)
 import Endemic.Eval
 import Endemic.Search
 import Endemic.Search.PseudoGenetic (pseudoGeneticRepair)
@@ -35,187 +36,125 @@ tESTSEED = 703_039_772
 tESTGENCONF :: GeneticConfiguration
 tESTGENCONF = def {crossoverRate = 0.95, mutationRate = 0.05, dropRate = 0.05}
 
+mkRepairTest :: (ProblemDescription -> IO (Set EFix)) -> Integer -> TestName -> FilePath -> [String] -> TestTree
+mkRepairTest how timeout tag file expected =
+  localOption (mkTimeout timeout) $
+    testCase tag $ do
+      setSeedGenSeed (tESTSEED + 5)
+      desc <- describeProblem def file
+      fixes <- how desc
+      fixesToDiffs desc fixes @?= expected
+
+mkGenConfTest :: Integer -> TestName -> FilePath -> [String] -> TestTree
+mkGenConfTest = mkRepairTest (\desc -> runGenMonad tESTGENCONF desc tESTSEED geneticSearchPlusPostprocessing)
+
+mkSearchTest :: SearchAlgorithm -> Integer -> TestName -> FilePath -> [String] -> TestTree
+mkSearchTest search_conf = mkRepairTest (runRepair search_conf)
+
+mkPseudoGenTest :: Integer -> TestName -> FilePath -> [String] -> TestTree
+mkPseudoGenTest = mkRepairTest (pseudoGeneticRepair def)
+
 tastyFixTests :: TestTree
 tastyFixTests =
   testGroup
     "Tasty fix tests"
-    [ localOption (mkTimeout 30_000_000) $
-        testCase "Repair TastyFix" $ do
-          let toFix = "tests/cases/TastyFix.hs"
-              repair_target = Nothing
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/TastyFix.hs b/tests/cases/TastyFix.hs",
-                      "--- a/tests/cases/TastyFix.hs",
-                      "+++ b/tests/cases/TastyFix.hs",
-                      "@@ -7,1 +7,1 @@ x = 2",
-                      "-x = 2",
-                      "+x = 3"
-                    ]
-                  ]
-
-          setSeedGenSeed (tESTSEED + 5)
-          (_, modul, [EProb {..}]) <-
-            moduleToProb (def {packages = def packages ++ ["tasty", "tasty-hunit"]}) toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- runGenMonad tESTGENCONF desc tESTSEED geneticSearchPlusPostprocessing
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
-          fixDiffs @?= expected,
-      localOption (mkTimeout 30_000_000) $
-        testCase "Repair TastyMix" $ do
-          let toFix = "tests/cases/TastyMix.hs"
-              repair_target = Nothing
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/TastyMix.hs b/tests/cases/TastyMix.hs",
-                      "--- a/tests/cases/TastyMix.hs",
-                      "+++ b/tests/cases/TastyMix.hs",
-                      "@@ -7,1 +7,1 @@ x = 2",
-                      "-x = 2",
-                      "+x = 3"
-                    ]
-                  ]
-
-          setSeedGenSeed tESTSEED
-          (_, modul, [EProb {..}]) <-
-            moduleToProb (def {packages = def packages ++ ["tasty", "tasty-hunit"]}) toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- runGenMonad tESTGENCONF desc tESTSEED geneticSearchPlusPostprocessing
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
-          fixDiffs @?= expected
+    [ mkGenConfTest 30_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/TastyFix.hs b/tests/cases/TastyFix.hs",
+              "--- a/tests/cases/TastyFix.hs",
+              "+++ b/tests/cases/TastyFix.hs",
+              "@@ -7,1 +7,1 @@ x = 2",
+              "-x = 2",
+              "+x = 3"
+            ]
+          ],
+      mkGenConfTest 30_000_000 "Repair TastyMix" "tests/cases/TastyMix.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/TastyMix.hs b/tests/cases/TastyMix.hs",
+              "--- a/tests/cases/TastyMix.hs",
+              "+++ b/tests/cases/TastyMix.hs",
+              "@@ -7,1 +7,1 @@ x = 2",
+              "-x = 2",
+              "+x = 3"
+            ]
+          ]
     ]
 
 randTests :: TestTree
 randTests =
   testGroup
     "Random search tests"
-    [ localOption (mkTimeout 60_000_000) $
-        testCase "Repair TastyFix" $ do
-          let toFix = "tests/cases/TastyFix.hs"
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/TastyFix.hs b/tests/cases/TastyFix.hs",
-                      "--- a/tests/cases/TastyFix.hs",
-                      "+++ b/tests/cases/TastyFix.hs",
-                      "@@ -7,1 +7,1 @@ x = 2",
-                      "-x = 2",
-                      "+x = 3"
-                    ]
-                  ]
-              randConf = def {randStopOnResults = True, randIgnoreFailing = True}
-          setSeedGenSeed (tESTSEED + 5)
-          fixes <- describeProblem def toFix >>= runRepair (Random randConf)
-          (_, modul, [EProb {..}]) <- moduleToProb def toFix Nothing
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
-          fixDiffs @?= expected
+    [ let conf = Random def {randStopOnResults = True, randIgnoreFailing = True}
+       in mkSearchTest conf 60_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs" $
+            map
+              unlines
+              [ [ "diff --git a/tests/cases/TastyFix.hs b/tests/cases/TastyFix.hs",
+                  "--- a/tests/cases/TastyFix.hs",
+                  "+++ b/tests/cases/TastyFix.hs",
+                  "@@ -7,1 +7,1 @@ x = 2",
+                  "-x = 2",
+                  "+x = 3"
+                ]
+              ]
     ]
 
 properGenTests :: TestTree
 properGenTests =
   testGroup
     "proper generation tests"
-    [ localOption (mkTimeout 60_000_000) $
-        testCase "Repair ThreeFixes" $ do
-          let toFix = "tests/cases/ThreeFixes.hs"
-              repair_target = Nothing
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/ThreeFixes.hs b/tests/cases/ThreeFixes.hs",
-                      "--- a/tests/cases/ThreeFixes.hs",
-                      "+++ b/tests/cases/ThreeFixes.hs",
-                      "@@ -20,1 +20,1 @@ brokenPair = (1, 2, 3)",
-                      "-brokenPair = (1, 2, 3)",
-                      "+brokenPair = (3, 4, 5)"
-                    ]
-                  ]
-          setSeedGenSeed (tESTSEED + 5)
-          (_, modul, [EProb {..}]) <- moduleToProb def toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- runGenMonad tESTGENCONF desc tESTSEED geneticSearchPlusPostprocessing
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes modul . getFixBinds) fixProgs
-          fixDiffs @?= expected
+    [ mkGenConfTest 60_000_000 "Repair ThreeFixes" "tests/cases/ThreeFixes.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/ThreeFixes.hs b/tests/cases/ThreeFixes.hs",
+              "--- a/tests/cases/ThreeFixes.hs",
+              "+++ b/tests/cases/ThreeFixes.hs",
+              "@@ -20,1 +20,1 @@ brokenPair = (1, 2, 3)",
+              "-brokenPair = (1, 2, 3)",
+              "+brokenPair = (3, 4, 5)"
+            ]
+          ]
     ]
 
 genTests :: TestTree
 genTests =
   testGroup
     "Generation tests"
-    [ localOption (mkTimeout 120_000_000) $
-        testCase "Repair TwoFixes" $ do
-          let toFix = "tests/cases/TwoFixes.hs"
-              repair_target = Nothing
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/TwoFixes.hs b/tests/cases/TwoFixes.hs",
-                      "--- a/tests/cases/TwoFixes.hs",
-                      "+++ b/tests/cases/TwoFixes.hs",
-                      "@@ -12,1 +12,1 @@ brokenPair = (1, 2)",
-                      "-brokenPair = (1, 2)",
-                      "+brokenPair = (3, 4)"
-                    ]
-                  ]
-
-          setSeedGenSeed (tESTSEED + 5)
-          (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- pseudoGeneticRepair def desc
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes mod . getFixBinds) fixProgs
-          fixDiffs @?= expected,
-      localOption (mkTimeout 75_000_000) $
-        testCase "Repair ThreeFixes" $ do
-          let toFix = "tests/cases/ThreeFixes.hs"
-              repair_target = Nothing
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/ThreeFixes.hs b/tests/cases/ThreeFixes.hs",
-                      "--- a/tests/cases/ThreeFixes.hs",
-                      "+++ b/tests/cases/ThreeFixes.hs",
-                      "@@ -20,1 +20,1 @@ brokenPair = (1, 2, 3)",
-                      "-brokenPair = (1, 2, 3)",
-                      "+brokenPair = (3, 4, 5)"
-                    ]
-                  ]
-
-          setSeedGenSeed (tESTSEED + 5)
-          (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- pseudoGeneticRepair def desc
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes mod . getFixBinds) fixProgs
-          fixDiffs @?= expected,
-      localOption (mkTimeout 90_000_000) $
-        testCase "Repair FourFixes" $ do
-          let toFix = "tests/cases/FourFixes.hs"
-              repair_target = Nothing
-              expected =
-                map
-                  unlines
-                  [ [ "diff --git a/tests/cases/FourFixes.hs b/tests/cases/FourFixes.hs",
-                      "--- a/tests/cases/FourFixes.hs",
-                      "+++ b/tests/cases/FourFixes.hs",
-                      "@@ -24,1 +24,1 @@ brokenPair = (1, 2, 3, 4)",
-                      "-brokenPair = (1, 2, 3, 4)",
-                      "+brokenPair = (3, 4, 5, 6)"
-                    ]
-                  ]
-          setSeedGenSeed (tESTSEED + 5)
-          (cc', mod, [tp@EProb {..}]) <- moduleToProb def toFix repair_target
-          desc <- describeProblem def toFix
-          fixes <- pseudoGeneticRepair def desc
-          let fixProgs = map (`replaceExpr` progAtTy e_prog e_ty) $ Set.toList fixes
-              fixDiffs = map (concatMap ppDiff . snd . applyFixes mod . getFixBinds) fixProgs
-          fixDiffs @?= expected
+    [ mkPseudoGenTest 120_000_000 "Repair TwoFixes" "tests/cases/TwoFixes.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/TwoFixes.hs b/tests/cases/TwoFixes.hs",
+              "--- a/tests/cases/TwoFixes.hs",
+              "+++ b/tests/cases/TwoFixes.hs",
+              "@@ -12,1 +12,1 @@ brokenPair = (1, 2)",
+              "-brokenPair = (1, 2)",
+              "+brokenPair = (3, 4)"
+            ]
+          ],
+      mkPseudoGenTest 75_000_000 "Repair ThreeFixes" "tests/cases/ThreeFixes.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/ThreeFixes.hs b/tests/cases/ThreeFixes.hs",
+              "--- a/tests/cases/ThreeFixes.hs",
+              "+++ b/tests/cases/ThreeFixes.hs",
+              "@@ -20,1 +20,1 @@ brokenPair = (1, 2, 3)",
+              "-brokenPair = (1, 2, 3)",
+              "+brokenPair = (3, 4, 5)"
+            ]
+          ],
+      mkPseudoGenTest 90_000_000 "Repair FourFixes" "tests/cases/FourFixes.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/FourFixes.hs b/tests/cases/FourFixes.hs",
+              "--- a/tests/cases/FourFixes.hs",
+              "+++ b/tests/cases/FourFixes.hs",
+              "@@ -24,1 +24,1 @@ brokenPair = (1, 2, 3, 4)",
+              "-brokenPair = (1, 2, 3, 4)",
+              "+brokenPair = (3, 4, 5, 6)"
+            ]
+          ]
     ]
 
+main :: IO ()
 main = defaultMain tests

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -110,7 +110,7 @@ exhaustiveTests :: TestTree
 exhaustiveTests =
   testGroup
     "Exhaustive search tests"
-    [ let conf = Exhaustive def {exhStopOnResults = True, exhIgnoreFailing = True}
+    [ let conf = Exhaustive def {exhStopOnResults = True}
        in mkSearchTest conf 60_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs" $
             map
               unlines

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -122,7 +122,7 @@ exhaustiveTests =
                   "+x = 3"
                 ]
               ],
-      let conf = Exhaustive def {exhStopOnResults = True, exhIgnoreFailing = True}
+      let conf = Exhaustive def {exhStopOnResults = True}
        in mkSearchTest conf 180_000_000 "Repair TwoFixes" "tests/cases/TwoFixes.hs" $
             map
               unlines


### PR DESCRIPTION
This reworks the repair stuff a bit to make it easier to write custom searches, and adds two new types of search, exhaustive (which checks all 1 replacement fixes, then all 2 replacement fixes, etc.) and random search. Fixes #37 