### PR TITLE
Unfold Tasty TestTrees

### DIFF
--- a/check-helpers/Check/Helpers.hs
+++ b/check-helpers/Check/Helpers.hs
@@ -10,6 +10,7 @@ import Test.QuickCheck.Random
 import Test.Tasty
 import Test.Tasty (defaultMain, localOption, mkTimeout)
 import Test.Tasty.Ingredients
+import qualified Test.Tasty.Runners as TR
 
 -- QuickCheck helpers
 qcCheckArgs :: Args
@@ -43,3 +44,11 @@ checkTastyTree timeout tt =
   catch
     (withArgs ["-q"] (fmap (const True) $ defaultMain $ localOption (mkTimeout (fromIntegral timeout)) tt))
     (return . (==) ExitSuccess)
+
+unfoldTastyTests :: TestTree -> [TestTree]
+unfoldTastyTests = TR.foldTestTree (TR.trivialFold {TR.foldSingle = fs'}) mempty
+  where
+    fs' opts name test = [TR.PlusTestOptions (opts <>) $ TR.SingleTest name test]
+
+testTreeNthTest :: Int -> TestTree -> TestTree
+testTreeNthTest n tree = (unfoldTastyTests tree) !! n

--- a/check-helpers/check-helpers.cabal
+++ b/check-helpers/check-helpers.cabal
@@ -1,7 +1,7 @@
 name: check-helpers
 cabal-version: 1.24
 build-type: Simple
-version: 0.0.2
+version: 0.0.3
 category: Compiler Plugin
 license: MIT
 license-file: LICENSE

--- a/check-helpers/check-helpers.cabal
+++ b/check-helpers/check-helpers.cabal
@@ -1,7 +1,7 @@
 name: check-helpers
 cabal-version: 1.24
 build-type: Simple
-version: 0.0.3
+version: 0.0.4
 category: Compiler Plugin
 license: MIT
 license-file: LICENSE
@@ -13,4 +13,6 @@ library
   exposed-modules: Check.Helpers
   build-depends: base >= 4 && < 5,
                  tasty >= 1.4 && < 1.5,
+                 containers >= 0.6 && < 0.7,
+                 stm >= 2.5 && < 2.6,
                  QuickCheck

--- a/resources/big_sample_config.json
+++ b/resources/big_sample_config.json
@@ -6,7 +6,8 @@
                 "packages": [
                         "base"
                 ],
-                "hole_lvl": 0
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true
         },
         "repair_config": {
                 "par_checks": true,

--- a/resources/docker_config.json
+++ b/resources/docker_config.json
@@ -9,7 +9,8 @@
                         "check-helpers",
                         "QuickCheck"
                 ],
-                "hole_lvl": 0
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true
         },
         "repair_config": {
                 "par_checks": true,

--- a/resources/exhaustive_search_config.json
+++ b/resources/exhaustive_search_config.json
@@ -22,9 +22,9 @@
         "search_algorithm": {
                 "tag": "Exhaustive",
                 "contents": {
-                        "exh_search_budget": 300,
-                        "exh_stop_on_results": true,
-                        "exh_batch_size": 10
+                        "exhaustive_search_budget": 300,
+                        "exhaustive_stop_on_results": true,
+                        "exhaustive_batch_size": 10
                 }
         },
         "log_config": {

--- a/resources/random_search_config.json
+++ b/resources/random_search_config.json
@@ -6,7 +6,8 @@
                 "packages": [
                         "base"
                 ],
-                "hole_lvl": 0
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true
         },
         "repair_config": {
                 "par_checks": true,

--- a/resources/sample_config.json
+++ b/resources/sample_config.json
@@ -6,7 +6,8 @@
                 "packages": [
                         "base"
                 ],
-                "hole_lvl": 0
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true
         },
         "repair_config": {
                 "par_checks": true,

--- a/resources/test_config.json
+++ b/resources/test_config.json
@@ -21,11 +21,18 @@
                 "save_patches": true
         },
         "search_algorithm": {
-                "tag": "Exhaustive",
+                "tag": "Genetic",
                 "contents": {
-                        "exhaustive_search_budget": 300,
-                        "exhaustive_stop_on_results": true,
-                        "exhaustive_batch_size": 10
+                        "mutation_rate": 5.0e-2,
+                        "crossover_rate": 0.95,
+                        "iterations": 50,
+                        "population_size": 64,
+                        "timeout_in_seconds": 300.0,
+                        "stop_on_results": true,
+                        "drop_rate": 5.0e-2,
+                        "try_minimize_fixes": false,
+                        "replace_winners": true,
+                        "use_parallel_map": true
                 }
         },
         "log_config": {
@@ -34,5 +41,5 @@
                 "log_timestamp": true,
                 "log_file": null
         },
-        "random_seed": -911372734310229019
+        "random_seed": 703039777
 }

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -222,21 +222,23 @@ instance Materializeable CompileConfig where
   data Unmaterialized CompileConfig = UmCompConf
     { umImportStmts :: Maybe [String],
       umPackages :: Maybe [String],
-      umHoleLvl :: Maybe Int
+      umHoleLvl :: Maybe Int,
+      umUnfoldTastyTests :: Maybe Bool
     }
     deriving (Show, Eq, Generic)
     deriving
       (FromJSON, ToJSON)
       via CustomJSON '[OmitNothingFields, RejectUnknownFields, FieldLabelModifier '[StripPrefix "um", CamelToSnake]] (Unmaterialized CompileConfig)
 
-  conjure = UmCompConf Nothing Nothing Nothing
+  conjure = UmCompConf Nothing Nothing Nothing Nothing
 
   override c Nothing = c
   override CompConf {..} (Just UmCompConf {..}) =
     CompConf
       { importStmts = fromMaybe importStmts umImportStmts,
         packages = fromMaybe packages umPackages,
-        hole_lvl = fromMaybe hole_lvl umHoleLvl
+        hole_lvl = fromMaybe hole_lvl umHoleLvl,
+        unfoldTastyTests = fromMaybe unfoldTastyTests umUnfoldTastyTests
       }
 
 -- | Configuration for the compilation itself
@@ -246,7 +248,8 @@ data CompileConfig = CompConf
     -- | a list of packages used for the compilation
     packages :: [String],
     -- | the "depth" of the holes, see general notes on this
-    hole_lvl :: Int
+    hole_lvl :: Int,
+    unfoldTastyTests :: Bool
   }
   deriving (Show, Eq, Generic)
   deriving
@@ -258,7 +261,8 @@ instance Default CompileConfig where
     CompConf
       { hole_lvl = 0,
         packages = ["base"],
-        importStmts = ["import Prelude"]
+        importStmts = ["import Prelude"],
+        unfoldTastyTests = True
       }
 
 -- | Configuration for the checking of repairs

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,6 +12,7 @@ import Data.Default (def)
 import Data.IORef (IORef, atomicModifyIORef', readIORef, writeIORef)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import Data.Time.LocalTime (utc)
 import Data.Version (showVersion)
@@ -169,7 +170,7 @@ main = do
     Repair _ target -> do
       -- Set the global flags
       setGlobalFlags conf
-
+      putStrLn $ "Repairing " ++ show target ++ " with seed " ++ show (fromJust randomSeed)
       (_, modul, probs) <- moduleToProb compileConfig target Nothing
       let (tp@EProb {..} : _) = if null probs then error "NO TARGET FOUND!" else probs
           RProb {..} = detranslate tp

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -170,7 +170,6 @@ main = do
     Repair _ target -> do
       -- Set the global flags
       setGlobalFlags conf
-      putStrLn $ "Repairing " ++ show target ++ " with seed " ++ show (fromJust randomSeed)
       (_, modul, probs) <- moduleToProb compileConfig target Nothing
       let (tp@EProb {..} : _) = if null probs then error "NO TARGET FOUND!" else probs
           RProb {..} = detranslate tp

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -5,7 +5,7 @@
 module Main where
 
 import Data.Default
-import Data.IORef (readIORef)
+import Data.IORef (readIORef, writeIORef)
 import Data.Maybe (isJust, mapMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -41,6 +41,12 @@ tESTSEED = 703_039_772
 
 tESTGENCONF :: GeneticConfiguration
 tESTGENCONF = def {crossoverRate = 0.95, mutationRate = 0.05, dropRate = 0.05}
+
+-- | For debugging tests
+setLogLevel :: LogLevel -> IO ()
+setLogLevel lvl = do
+  lc <- readIORef lOGCONFIG
+  writeIORef lOGCONFIG lc {logLevel = lvl}
 
 mkRepairTest :: (ProblemDescription -> IO (Set EFix)) -> Integer -> TestName -> FilePath -> [String] -> TestTree
 mkRepairTest how timeout tag file expected =
@@ -84,6 +90,17 @@ tastyFixTests =
               "@@ -7,1 +7,1 @@ x = 2",
               "-x = 2",
               "+x = 3"
+            ]
+          ],
+      mkGenConfTest 180_000_000 "Repair TastyTwoFix" "tests/cases/TastyTwoFix.hs" $
+        map
+          unlines
+          [ [ "diff --git a/tests/cases/TastyTwoFix.hs b/tests/cases/TastyTwoFix.hs",
+              "--- a/tests/cases/TastyTwoFix.hs",
+              "+++ b/tests/cases/TastyTwoFix.hs",
+              "@@ -7,1 +7,1 @@ wrong_pair = (1, 2)",
+              "-wrong_pair = (1, 2)",
+              "+wrong_pair = (3, 4)"
             ]
           ]
     ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -220,7 +220,12 @@ failingPropsTests =
           setSeedGenSeed tESTSEED
           tp <- translate cc rp
           failed_props <- failingProps def cc tp
-          map showUnsafe failed_props @?= props
+          map showUnsafe failed_props @?= props,
+      localOption (mkTimeout 10_000_000) $
+        testCase "Two failing TastyProps" $ do
+          desc@ProbDesc {..} <- describeProblem def "tests/cases/TastyTwoFix.hs"
+          failed_props <- failingProps repConf compConf progProblem
+          length failed_props @?= 2
     ]
 
 counterExampleTests =

--- a/tests/cases/TastyTwoFix.hs
+++ b/tests/cases/TastyTwoFix.hs
@@ -1,0 +1,16 @@
+module TastyTwoFix where
+
+import Test.Tasty
+import Test.Tasty.HUnit (testCase, (@?=))
+
+wrong_pair :: (Int, Int)
+wrong_pair = (1, 2)
+
+test :: TestTree
+test =
+  testGroup
+    "twofix"
+    [ testCase "Test 1" (fst wrong_pair @?= 3),
+      testCase "Test 2" (snd wrong_pair @?= 4),
+      testCase "Test 3 (should work)" (uncurry (<) wrong_pair @?= True)
+    ]


### PR DESCRIPTION
This adds a flag to unfold tasty test trees into multiple tests, so they are counted as multiple small tests instead of one big one.