### PR TITLE
[Minor] Speed up search by precomputing possible fixes at start

### DIFF
--- a/resources/big_sample_config.json
+++ b/resources/big_sample_config.json
@@ -12,7 +12,8 @@
         "repair_config": {
                 "par_checks": true,
                 "use_interpreted": true,
-                "timeout": 1000000
+                "timeout": 1000000,
+                "precompute_fixes": true
         },
         "output_config": {
                 "locale": null,

--- a/resources/random_search_config.json
+++ b/resources/random_search_config.json
@@ -12,7 +12,8 @@
         "repair_config": {
                 "par_checks": true,
                 "use_interpreted": true,
-                "timeout": 1000000
+                "timeout": 1000000,
+                "precompute_fixes": false
         },
         "output_config": {
                 "locale": null,

--- a/resources/sample_config.json
+++ b/resources/sample_config.json
@@ -12,7 +12,8 @@
         "repair_config": {
                 "par_checks": true,
                 "use_interpreted": true,
-                "timeout": 1000000
+                "timeout": 1000000,
+                "precompute_fixes": true
         },
         "output_config": {
                 "locale": null,

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -347,7 +347,9 @@ data ProblemDescription = ProbDesc
     compConf :: CompileConfig,
     repConf :: RepairConfig,
     -- | The parsed module, if available
-    probModule :: Maybe ParsedModule
+    probModule :: Maybe ParsedModule,
+    -- | Fix candidates, if available
+    initialFixes :: Maybe [EFix]
   }
 
 setProg :: ProblemDescription -> EExpr -> ProblemDescription

--- a/src/Endemic/Eval.hs
+++ b/src/Endemic/Eval.hs
@@ -898,12 +898,3 @@ getExprFitCands cc expr = runGhc (Just libdir) $ do
           not (isEmptyVarSet (ctFreeVarSet ct))
             && anyFVMentioned ct
             && not (isHoleCt ct)
-
-describeProblem :: Configuration -> FilePath -> IO ProblemDescription
-describeProblem conf@Conf {compileConfig = cc, repairConfig = repConf} fp = do
-  (compConf, modul, [progProblem@EProb {..}]) <- moduleToProb cc fp Nothing
-  let probModule = Just modul
-  exprFitCands <-
-    getExprFitCands compConf $
-      noLoc $ HsLet NoExtField e_ctxt $ noLoc undefVar
-  return $ ProbDesc {..}

--- a/src/Endemic/Repair.hs
+++ b/src/Endemic/Repair.hs
@@ -444,13 +444,15 @@ describeProblem conf@Conf {compileConfig = cc, repairConfig = repConf} fp = do
       initialFixes = Nothing
       desc' = ProbDesc {..}
 
-  let inContext = noLoc . HsLet NoExtField e_ctxt
-      addContext = snd . fromJust . flip fillHole (inContext hole) . unLoc
-  nzh <- findEvaluatedHoles desc'
-  fits <- collectStats $ getHoleFits compConf exprFitCands (map addContext nzh)
-  processed_fits <- collectStats $ processFits compConf fits
-  let fix_cands :: [(EFix, EExpr)]
-      fix_cands = map (first Map.fromList) (zip nzh processed_fits >>= uncurry replacements)
-      initialFixes' = Just $ map fst fix_cands
-
-  return $ desc' {initialFixes = initialFixes'}
+  if repPrecomputeFixes repConf
+    then do
+      let inContext = noLoc . HsLet NoExtField e_ctxt
+          addContext = snd . fromJust . flip fillHole (inContext hole) . unLoc
+      nzh <- findEvaluatedHoles desc'
+      fits <- collectStats $ getHoleFits compConf exprFitCands (map addContext nzh)
+      processed_fits <- collectStats $ processFits compConf fits
+      let fix_cands :: [(EFix, EExpr)]
+          fix_cands = map (first Map.fromList) (zip nzh processed_fits >>= uncurry replacements)
+          initialFixes' = Just $ map fst fix_cands
+      return $ desc' {initialFixes = initialFixes'}
+    else return desc'

--- a/src/Endemic/Search/Exhaustive/Search.hs
+++ b/src/Endemic/Search/Exhaustive/Search.hs
@@ -39,8 +39,14 @@ exhaustiveRepair r@ExhaustiveConf {..} desc@ProbDesc {..} = do
   -- We use BFS, i.e. check all 1 level fixes, then all 2 level fixes, etc:
   logStr VERBOSE "Starting exhaustive search!"
   -- Note: we don't have to recompute the fixes again and again
-  all_fix_combs <- lazyAllCombsByLevel . map fst <$> repairAttempt desc
-  let loop :: Set EFix -> [[EFix]] -> IO (Set EFix)
+  all_fix_combs <-
+    lazyAllCombsByLevel <$> case initialFixes of
+      Just fixes -> return fixes
+      _ -> map fst <$> repairAttempt desc
+
+  let isFixed (Right x) = x
+      isFixed (Left ps) = and ps
+      loop :: Set EFix -> [[EFix]] -> IO (Set EFix)
       loop _ [] = return Set.empty
       loop checked ([] : lvls) = loop checked lvls
       loop checked (lvl : lvls) = do

--- a/src/Endemic/Search/PseudoGenetic/Search.hs
+++ b/src/Endemic/Search/PseudoGenetic/Search.hs
@@ -25,7 +25,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Endemic.Configuration
 import Endemic.Eval (getExprFitCands)
-import Endemic.Repair (repairAttempt)
+import Endemic.Repair (checkFixes, repairAttempt)
 import Endemic.Search.PseudoGenetic.Configuration
 import Endemic.Traversals (replaceExpr)
 import Endemic.Types
@@ -115,9 +115,13 @@ pseudoGeneticRepair
     { compConf = cc,
       repConf = rc,
       progProblem = prob@EProb {..},
-      exprFitCands = efcs
+      exprFitCands = efcs,
+      initialFixes = mb_initial_fixes
     } = do
-    first_attempt <- collectStats $ repairAttempt desc
+    first_attempt <- case mb_initial_fixes of
+      Just fixes ->
+        zip fixes <$> checkFixes desc (map (`replaceExpr` progAtTy e_prog e_ty) fixes)
+      _ -> collectStats $ repairAttempt desc
     if not $ null $ successful first_attempt
       then return (Set.fromList $ map fst $ successful first_attempt)
       else do

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -9,7 +9,7 @@ import Data.IORef (readIORef, writeIORef)
 import Data.Maybe (isJust, mapMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Endemic (getExprFitCands)
+import Endemic (describeProblem, getExprFitCands)
 import Endemic.Configuration
 import Endemic.Diff (applyFixes, fixesToDiffs, getFixBinds, ppDiff)
 import Endemic.Eval
@@ -156,7 +156,7 @@ exhaustiveTests =
 properGenTests :: TestTree
 properGenTests =
   testGroup
-    "proper generation tests"
+    "Genetic search tests"
     [ mkGenConfTest 60_000_000 "Repair ThreeFixes" "tests/cases/ThreeFixes.hs" $
         map
           unlines
@@ -173,7 +173,7 @@ properGenTests =
 genTests :: TestTree
 genTests =
   testGroup
-    "Generation tests"
+    "PseudoGenetic search tests"
     [ mkPseudoGenTest 120_000_000 "Repair TwoFixes" "tests/cases/TwoFixes.hs" $
         map
           unlines


### PR DESCRIPTION
Since the fits themselves don't actually change during the repair process (at least not until we start doing fixes with deeper holes), we can gain a heavy speed-boost by precomputing the fixes for every single hole at the start, and then use those.