### PR TITLE
[Feature] Add refinement hole-fits. Fixes #59

### DIFF
--- a/resources/big_sample_config.json
+++ b/resources/big_sample_config.json
@@ -9,6 +9,7 @@
                 "mod_base": [],
                 "additional_targets": [],
                 "hole_lvl": 0,
+                "hole_depth": 1,
                 "unfold_tasty_tests": true,
                 "temp_dir_base": "./temp_dir",
                 "par_checks": true,

--- a/resources/docker_config.json
+++ b/resources/docker_config.json
@@ -12,6 +12,7 @@
                 "mod_base": [],
                 "additional_targets": [],
                 "hole_lvl": 0,
+                "hole_depth": 1,
                 "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
                 "par_checks": true,

--- a/resources/exhaustive_search_config.json
+++ b/resources/exhaustive_search_config.json
@@ -9,6 +9,7 @@
                 "mod_base": [],
                 "additional_targets": [],
                 "hole_lvl": 0,
+                "hole_depth": 1,
                 "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
                 "par_checks": true,

--- a/resources/random_search_config.json
+++ b/resources/random_search_config.json
@@ -9,6 +9,7 @@
                 "mod_base": [],
                 "additional_targets": [],
                 "hole_lvl": 0,
+                "hole_depth": 1,
                 "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
                 "par_checks": true,

--- a/resources/sample_config.json
+++ b/resources/sample_config.json
@@ -9,6 +9,7 @@
                 "mod_base": [],
                 "additional_targets": [],
                 "hole_lvl": 0,
+                "hole_depth": 1,
                 "unfold_tasty_tests": true,
                 "temp_dir_base": "./temp_dir",
                 "par_checks": true,

--- a/resources/test_config.json
+++ b/resources/test_config.json
@@ -9,6 +9,7 @@
                 "mod_base": [],
                 "additional_targets": [],
                 "hole_lvl": 0,
+                "hole_depth": 1,
                 "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
                 "par_checks": true,

--- a/src/Endemic/Eval.hs
+++ b/src/Endemic/Eval.hs
@@ -132,7 +132,7 @@ initGhcCtxt' ::
 initGhcCtxt' use_cache CompConf {..} local_exprs = do
   liftIO $ logStr DEBUG "Initializing GHC..."
   -- First we have to add "base" to scope
-  flags <- config hole_lvl <$> getSessionDynFlags
+  flags <- config holeLvl <$> getSessionDynFlags
   --`dopt_set` Opt_D_dump_json
   plugRef <- liftIO $ newIORef initialHoleFitState
   let flags' =
@@ -200,7 +200,7 @@ getHoleFitsFromError plugRef err = do
   when (null res) (printException err)
   let gs = groupBy (sameHole `on` fst) res
       allFitsOfHole ((th, f) : rest) = (th, concat $ f : map snd rest)
-      allFitsOfHole [] = error "no-fits!"
+      allFitsOfHole [] = error "no-holes!"
       valsAndRefs = map ((partition part . snd) . allFitsOfHole) gs
   return $ Left valsAndRefs
   where

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -117,7 +117,16 @@ specialTests =
         120_000_000
         "Non-interpreted"
         "tests/cases/LoopBreaker.hs",
-      mkGenConfTestEx 60_000_000 "Wrapped fits" "tests/cases/Wrap.hs"
+      mkGenConfTestEx 60_000_000 "Wrapped fits" "tests/cases/Wrap.hs",
+      mkRepairTest
+        ( def
+            { compileConfig = def {holeLvl = 2, useInterpreted = False}
+            }
+        )
+        (runGenRepair' (tESTGENCONF {populationSize = 128}))
+        180_000_000
+        "Refinement test"
+        "tests/cases/SimpleRefinement.hs"
     ]
 
 main :: IO ()

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -45,7 +45,7 @@ tests =
 -- Helpers
 compileParsedCheck :: HasCallStack => CompileConfig -> EExpr -> IO Dynamic
 compileParsedCheck cc expr =
-  runGhc' (cc {hole_lvl = 0}) $
+  runGhc' (cc {holeLvl = 0}) $
     dynCompileParsedExpr `reportOnError` expr
 
 runJustParseExpr :: CompileConfig -> RExpr -> IO (LHsExpr GhcPs)
@@ -74,8 +74,7 @@ repairTests =
         testCase "Basic Repair `foldl (-) 0`" $ do
           let cc =
                 def
-                  { hole_lvl = 2,
-                    packages = ["base", "process", "QuickCheck"],
+                  { packages = ["base", "process", "QuickCheck"],
                     importStmts = ["import Prelude hiding (id, ($), ($!), asTypeOf)"]
                   }
               ty = "[Int] -> Int"
@@ -195,8 +194,7 @@ failingPropsTests =
         testCase "Only one failing prop" $ do
           let cc =
                 def
-                  { hole_lvl = 2,
-                    packages = ["base", "process", "QuickCheck"],
+                  { packages = ["base", "process", "QuickCheck"],
                     importStmts = ["import Prelude hiding (id, ($), ($!), asTypeOf)"]
                   }
               ty = "[Int] -> Int"
@@ -234,8 +232,7 @@ counterExampleTests =
         testCase "Only one counter example" $ do
           let cc =
                 def
-                  { hole_lvl = 2,
-                    packages = ["base", "process", "QuickCheck"],
+                  { packages = ["base", "process", "QuickCheck"],
                     importStmts = ["import Prelude hiding (id, ($), ($!), asTypeOf)"]
                   }
               ty = "[Int] -> Int"
@@ -264,8 +261,7 @@ counterExampleTests =
         testCase "Multiple examples" $ do
           let cc =
                 def
-                  { hole_lvl = 2,
-                    packages = ["base", "process", "QuickCheck"],
+                  { packages = ["base", "process", "QuickCheck"],
                     importStmts = ["import Prelude hiding (id, ($), ($!), asTypeOf)"]
                   }
               ty = "Int -> Int -> Int"

--- a/tests/cases/SimpleRefinement.hs
+++ b/tests/cases/SimpleRefinement.hs
@@ -1,0 +1,24 @@
+module SimpleRefinement where
+
+f :: [Int] -> Int
+f = foldr (-) 1
+
+-- We want foldl (+) 2 here
+
+prop_isSumPlus2 :: [Int] -> Bool
+prop_isSumPlus2 xs = f xs == sum xs + 2
+
+two :: Int
+two = 2
+
+main :: IO ()
+main = putStrLn "hello, world"
+
+---- EXPECTED ----
+-- diff --git a/tests/cases/SimpleRefinement.hs b/tests/cases/SimpleRefinement.hs
+-- --- a/tests/cases/SimpleRefinement.hs
+-- +++ b/tests/cases/SimpleRefinement.hs
+-- @@ -4,1 +4,1 @@ f = foldr (-) 1
+-- -f = foldr (-) 1
+-- +f = (foldl (+) two)
+---- END EXPECTED ----


### PR DESCRIPTION
By adding refinement hole-fits, we get exponentially more valid fits for any candidate, by enabling fits with additional holes (and those holes are then fit with everything in scope). This might help with more complex programs. 
Due to #65, and the fact that using refinement-hole fits is a lot more likely to generate non-trivial loops can make refinement fits freeze-up more often.  After #66 was fixed we could run it properly, and it gives good results, e.g.:

```haskell
module SimpleRefinement where

f :: [Int] -> Int
f = foldr (-) 1

-- We want foldl (+) 2 here

prop_isSumPlus2 :: [Int] -> Bool
prop_isSumPlus2 xs = f xs == sum xs + 2

two :: Int
two = 2

main :: IO ()
main = putStrLn "hello, world"

---- EXPECTED ----
-- diff --git a/tests/cases/SimpleRefinement.hs b/tests/cases/SimpleRefinement.hs
-- --- a/tests/cases/SimpleRefinement.hs
-- +++ b/tests/cases/SimpleRefinement.hs
-- @@ -4,1 +4,1 @@ f = foldr (-) 1
-- -f = foldr (-) 1
-- +f = (foldl (+) two)
---- END EXPECTED ----
```

which I think is pretty neat!      
