### PR TITLE
[Feature] Adds function fits. Fixes #70

### DIFF
--- a/resources/big_sample_config.json
+++ b/resources/big_sample_config.json
@@ -10,13 +10,14 @@
                 "additional_targets": [],
                 "hole_lvl": 0,
                 "unfold_tasty_tests": true,
-                "temp_dir_base": "./fake_targets",
+                "temp_dir_base": "./temp_dir",
+                "par_checks": true,
                 "randomize_hpc_dir": true,
                 "randomize_hi_dir": true,
-                "par_checks": true,
                 "use_interpreted": true,
                 "timeout": 1000000,
-                "precompute_fixes": true
+                "precompute_fixes": true,
+                "allow_function_fits": true
         },
         "output_config": {
                 "locale": null,

--- a/resources/docker_config.json
+++ b/resources/docker_config.json
@@ -9,17 +9,18 @@
                         "check-helpers",
                         "QuickCheck"
                 ],
-                "hole_lvl": 0,
-                "unfold_tasty_tests": true,
                 "mod_base": [],
                 "additional_targets": [],
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
+                "par_checks": true,
                 "randomize_hpc_dir": true,
                 "randomize_hi_dir": true,
-                "par_checks": true,
                 "use_interpreted": true,
                 "timeout": 1000000,
-                "precompute_fixes": true
+                "precompute_fixes": true,
+                "allow_function_fits": true
         },
         "output_config": {
                 "locale": null,
@@ -41,6 +42,12 @@
                         "replace_winners": true,
                         "use_parallel_map": true
                 }
+        },
+        "log_config": {
+                "log_loc": false,
+                "log_level": "WARN",
+                "log_timestamp": true,
+                "log_file": null
         },
         "random_seed": 42
 }

--- a/resources/exhaustive_search_config.json
+++ b/resources/exhaustive_search_config.json
@@ -6,17 +6,18 @@
                 "packages": [
                         "base"
                 ],
-                "hole_lvl": 0,
-                "unfold_tasty_tests": true,
                 "mod_base": [],
                 "additional_targets": [],
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
+                "par_checks": true,
                 "randomize_hpc_dir": true,
                 "randomize_hi_dir": true,
-                "par_checks": true,
                 "use_interpreted": true,
                 "timeout": 1000000,
-                "precompute_fixes": true
+                "precompute_fixes": true,
+                "allow_function_fits": true
         },
         "output_config": {
                 "locale": null,
@@ -38,5 +39,5 @@
                 "log_timestamp": true,
                 "log_file": null
         },
-        "random_seed": -911372734310229019
+        "random_seed": -911372734310229000
 }

--- a/resources/random_search_config.json
+++ b/resources/random_search_config.json
@@ -6,17 +6,18 @@
                 "packages": [
                         "base"
                 ],
-                "hole_lvl": 0,
-                "unfold_tasty_tests": true,
                 "mod_base": [],
                 "additional_targets": [],
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
+                "par_checks": true,
                 "randomize_hpc_dir": true,
                 "randomize_hi_dir": true,
-                "par_checks": true,
                 "use_interpreted": true,
                 "timeout": 1000000,
-                "precompute_fixes": true
+                "precompute_fixes": true,
+                "allow_function_fits": true
         },
         "output_config": {
                 "locale": null,
@@ -39,5 +40,5 @@
                 "log_timestamp": true,
                 "log_file": null
         },
-        "random_seed": -3573107736776895748
+        "random_seed": -3573107736776896000
 }

--- a/resources/sample_config.json
+++ b/resources/sample_config.json
@@ -10,13 +10,14 @@
                 "additional_targets": [],
                 "hole_lvl": 0,
                 "unfold_tasty_tests": true,
-                "temp_dir_base": "./fake_targets",
+                "temp_dir_base": "./temp_dir",
+                "par_checks": true,
                 "randomize_hpc_dir": true,
                 "randomize_hi_dir": true,
-                "par_checks": true,
                 "use_interpreted": true,
                 "timeout": 1000000,
-                "precompute_fixes": true
+                "precompute_fixes": true,
+                "allow_function_fits": true
         },
         "output_config": {
                 "locale": null,

--- a/resources/test_config.json
+++ b/resources/test_config.json
@@ -6,16 +6,18 @@
                 "packages": [
                         "base"
                 ],
-                "hole_lvl": 0,
-                "unfold_tasty_tests": true,
                 "mod_base": [],
                 "additional_targets": [],
+                "hole_lvl": 0,
+                "unfold_tasty_tests": true,
                 "temp_dir_base": "./fake_targets",
+                "par_checks": true,
                 "randomize_hpc_dir": true,
                 "randomize_hi_dir": true,
-                "par_checks": true,
                 "use_interpreted": true,
-                "timeout": 1000000
+                "timeout": 1000000,
+                "precompute_fixes": true,
+                "allow_function_fits": true
         },
         "output_config": {
                 "locale": null,
@@ -26,13 +28,13 @@
         "search_algorithm": {
                 "tag": "Genetic",
                 "contents": {
-                        "mutation_rate": 5.0e-2,
+                        "mutation_rate": 0.05,
                         "crossover_rate": 0.95,
                         "iterations": 50,
                         "population_size": 64,
-                        "timeout_in_seconds": 300.0,
+                        "timeout_in_seconds": 300,
                         "stop_on_results": true,
-                        "drop_rate": 5.0e-2,
+                        "drop_rate": 0.05,
                         "try_minimize_fixes": false,
                         "replace_winners": true,
                         "use_parallel_map": true

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -227,8 +227,9 @@ instance Materializeable CompileConfig where
       umRandomizeHiDir :: Maybe Bool,
       umParChecks :: Maybe Bool,
       umUseInterpreted :: Maybe Bool,
+      umTimeout :: Maybe Integer,
       umPrecomputeFixes :: Maybe Bool,
-      umTimeout :: Maybe Integer
+      umAllowFunctionFits :: Maybe Bool
     }
     deriving (Show, Eq, Generic)
     deriving
@@ -237,6 +238,7 @@ instance Materializeable CompileConfig where
 
   conjure =
     UmCompConf
+      Nothing
       Nothing
       Nothing
       Nothing
@@ -266,7 +268,8 @@ instance Materializeable CompileConfig where
         parChecks = fromMaybe parChecks umParChecks,
         useInterpreted = fromMaybe useInterpreted umUseInterpreted,
         timeout = fromMaybe timeout umTimeout,
-        precomputeFixes = fromMaybe precomputeFixes umPrecomputeFixes
+        precomputeFixes = fromMaybe precomputeFixes umPrecomputeFixes,
+        allowFunctionFits = fromMaybe allowFunctionFits umAllowFunctionFits
       }
 
 -- | Configuration for the compilation itself
@@ -313,7 +316,10 @@ data CompileConfig = CompConf
     -- cases, but can slow down if we have big
     -- programs and aren't considering all of it
     -- (e.t. random search).
-    precomputeFixes :: Bool
+    precomputeFixes :: Bool,
+    -- Whether to allow fits of the type `(_ x)` where x is some identifier
+    -- in the code. Makes the search space bigger, but finds more fits.
+    allowFunctionFits :: Bool
   }
   deriving (Show, Eq, Generic)
   deriving
@@ -335,7 +341,8 @@ instance Default CompileConfig where
         randomizeHiDir = True,
         useInterpreted = True,
         timeout = 1_000_000,
-        precomputeFixes = True
+        precomputeFixes = True,
+        allowFunctionFits = True
       }
 
 instance Default LogConfig where

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -39,6 +39,9 @@ tests =
 runGenRepair :: ProblemDescription -> IO (Set EFix)
 runGenRepair desc = runGenMonad tESTGENCONF desc tESTSEED geneticSearchPlusPostprocessing
 
+runGenRepair' :: GeneticConfiguration -> ProblemDescription -> IO (Set EFix)
+runGenRepair' gen_conf desc = runGenMonad gen_conf desc tESTSEED geneticSearchPlusPostprocessing
+
 mkGenConfTestEx :: Integer -> TestName -> FilePath -> TestTree
 mkGenConfTestEx = mkRepairTest def runGenRepair
 
@@ -84,7 +87,8 @@ properGenTests =
     "Genetic search tests"
     [ mkGenConfTestEx 180_000_000 "Repair TwoFixes" "tests/cases/TwoFixes.hs",
       mkGenConfTestEx 180_000_000 "Repair ThreeFixes" "tests/cases/ThreeFixes.hs",
-      mkGenConfTestEx 180_000_000 "Repair FourFixes" "tests/cases/FourFixes.hs"
+      -- With all the new fixes, we need to bump the population size
+      mkRepairTest def (runGenRepair' tESTGENCONF {populationSize = 92}) 180_000_000 "Repair FourFixes" "tests/cases/FourFixes.hs"
     ]
 
 genTests :: TestTree

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -109,7 +109,8 @@ specialTests =
         runGenRepair
         120_000_000
         "Non-interpreted"
-        "tests/cases/LoopBreaker.hs"
+        "tests/cases/LoopBreaker.hs",
+      mkGenConfTestEx 60_000_000 "Wrapped fits" "tests/cases/Wrap.hs"
     ]
 
 main :: IO ()

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -42,6 +42,9 @@ runGenRepair desc = runGenMonad tESTGENCONF desc tESTSEED geneticSearchPlusPostp
 mkGenConfTestEx :: Integer -> TestName -> FilePath -> TestTree
 mkGenConfTestEx = mkRepairTest def runGenRepair
 
+mkSearchTestExPartial :: SearchAlgorithm -> Integer -> TestName -> FilePath -> Maybe [Int] -> TestTree
+mkSearchTestExPartial search_conf timeout tag file = mkRepairTest' def (runRepair search_conf) timeout tag file Nothing
+
 mkSearchTestEx :: SearchAlgorithm -> Integer -> TestName -> FilePath -> TestTree
 mkSearchTestEx search_conf = mkRepairTest def (runRepair search_conf)
 
@@ -62,7 +65,7 @@ randTests =
   testGroup
     "Random search tests"
     [ let conf = Random def {randStopOnResults = True, randIgnoreFailing = True}
-       in mkSearchTestEx conf 180_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs"
+       in mkSearchTestExPartial conf 180_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs" (Just [1])
     ]
 
 exhaustiveTests :: TestTree
@@ -70,7 +73,7 @@ exhaustiveTests =
   testGroup
     "Exhaustive search tests"
     [ let conf = Exhaustive def {exhStopOnResults = True}
-       in mkSearchTestEx conf 180_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs",
+       in mkSearchTestExPartial conf 180_000_000 "Repair TastyFix" "tests/cases/TastyFix.hs" (Just [1]),
       let conf = Exhaustive def {exhStopOnResults = True}
        in mkSearchTestEx conf 180_000_000 "Repair TwoFixes" "tests/cases/TwoFixes.hs"
     ]

--- a/tests/cases/TastyFix.hs
+++ b/tests/cases/TastyFix.hs
@@ -15,5 +15,12 @@ test = testCase "Test 1" (x @?= 3)
 -- +++ b/tests/cases/TastyFix.hs
 -- @@ -7,1 +7,1 @@ x = 2
 -- -x = 2
+-- +x = (succ (2))
+--
+-- diff --git a/tests/cases/TastyFix.hs b/tests/cases/TastyFix.hs
+-- --- a/tests/cases/TastyFix.hs
+-- +++ b/tests/cases/TastyFix.hs
+-- @@ -7,1 +7,1 @@ x = 2
+-- -x = 2
 -- +x = 3
 ---- END EXPECTED ----

--- a/tests/cases/TastyMix.hs
+++ b/tests/cases/TastyMix.hs
@@ -19,5 +19,12 @@ test = testCase "Test 1" (x @?= 3)
 -- +++ b/tests/cases/TastyMix.hs
 -- @@ -7,1 +7,1 @@ x = 2
 -- -x = 2
+-- +x = (succ (2))
+--
+-- diff --git a/tests/cases/TastyMix.hs b/tests/cases/TastyMix.hs
+-- --- a/tests/cases/TastyMix.hs
+-- +++ b/tests/cases/TastyMix.hs
+-- @@ -7,1 +7,1 @@ x = 2
+-- -x = 2
 -- +x = 3
 ---- END EXPECTED ----

--- a/tests/cases/UsesDependency.hs
+++ b/tests/cases/UsesDependency.hs
@@ -24,6 +24,13 @@ one = 1
 -- +++ b/tests/cases/UsesDependency.hs
 -- @@ -9,1 +9,1 @@ result = dependency + 3
 -- -result = dependency + 3
+-- +result = dependency + (signum (3))
+--
+-- diff --git a/tests/cases/UsesDependency.hs b/tests/cases/UsesDependency.hs
+-- --- a/tests/cases/UsesDependency.hs
+-- +++ b/tests/cases/UsesDependency.hs
+-- @@ -9,1 +9,1 @@ result = dependency + 3
+-- -result = dependency + 3
 -- +result = dependency + 1
 --
 -- diff --git a/tests/cases/UsesDependency.hs b/tests/cases/UsesDependency.hs

--- a/tests/cases/Wrap.hs
+++ b/tests/cases/Wrap.hs
@@ -1,0 +1,26 @@
+module Wrap where
+
+onlyGoodOnes :: [Int] -> [Int]
+onlyGoodOnes = filter even
+
+xs :: [Int]
+xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+prop_allEven :: Bool
+prop_allEven = all even xs && not (null xs)
+
+---- EXPECTED ----
+-- diff --git a/tests/cases/Wrap.hs b/tests/cases/Wrap.hs
+-- --- a/tests/cases/Wrap.hs
+-- +++ b/tests/cases/Wrap.hs
+-- @@ -7,1 +7,1 @@ xs = [1, 2, 3, 4, 5, 6, 7, 8, ...
+-- -xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+-- +xs = ((filter even) ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+--
+-- diff --git a/tests/cases/Wrap.hs b/tests/cases/Wrap.hs
+-- --- a/tests/cases/Wrap.hs
+-- +++ b/tests/cases/Wrap.hs
+-- @@ -7,1 +7,1 @@ xs = [1, 2, 3, 4, 5, 6, 7, 8, ...
+-- -xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+-- +xs = (onlyGoodOnes ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+---- END EXPECTED ----

--- a/tests/cases/unnamed.hs
+++ b/tests/cases/unnamed.hs
@@ -14,4 +14,11 @@ main = putStrLn "hello, world"
 -- @@ -5,1 +5,1 @@ x = 4
 -- -x = 4
 -- +x = 5
+--
+-- diff --git a/tests/cases/unnamed.hs b/tests/cases/unnamed.hs
+-- --- a/tests/cases/unnamed.hs
+-- +++ b/tests/cases/unnamed.hs
+-- @@ -5,1 +5,1 @@ x = 4
+-- -x = 4
+-- +x = (succ (4))
 ---- END EXPECTED ----


### PR DESCRIPTION
This adds hole fits of the type `(_ xs)` where `xs` is some part of the target. E.g

```haskell
module Wrap where

onlyGoodOnes :: [Int] -> [Int]
onlyGoodOnes = filter even

xs :: [Int]
xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

prop_allEven :: Bool
prop_allEven = all even xs && not (null xs)

---- EXPECTED ----
-- diff --git a/tests/cases/Wrap.hs b/tests/cases/Wrap.hs
-- --- a/tests/cases/Wrap.hs
-- +++ b/tests/cases/Wrap.hs
-- @@ -7,1 +7,1 @@ xs = [1, 2, 3, 4, 5, 6, 7, 8, ...
-- -xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-- +xs = ((filter even) ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
--
-- diff --git a/tests/cases/Wrap.hs b/tests/cases/Wrap.hs
-- --- a/tests/cases/Wrap.hs
-- +++ b/tests/cases/Wrap.hs
-- @@ -7,1 +7,1 @@ xs = [1, 2, 3, 4, 5, 6, 7, 8, ...
-- -xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-- +xs = (onlyGoodOnes ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
---- END EXPECTED ----
```

Since adding a filter or check at the end is a very common fix, I think this will allow us to fix a lot more program.s