### PR TITLE
[Bugfix] Add main-function to unnamed modules. Fixes #77

### DIFF
--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -405,8 +405,9 @@ data ProblemDescription = ProbDesc
     exprFitCands :: [ExprFitCand],
     compConf :: CompileConfig,
     addConf :: AdditionalConf,
-    -- | The typechecked module, if available
-    probModule :: Maybe TypecheckedModule,
+    probModuleParsed :: Maybe ParsedModule,
+    -- | The typechecked module. Possibly faked in case of unnamed modules
+    probModuleTypechecked :: Maybe TypecheckedModule,
     -- | Fix candidates, if available
     initialFixes :: Maybe [EFix]
   }

--- a/src/Endemic/Diff.hs
+++ b/src/Endemic/Diff.hs
@@ -148,8 +148,8 @@ ppDiffs diffs = intercalate "\n" $ map sameFDiffs byLoc
     toLoc (UnhelpfulSpan s) = unpackFS s
 
 fixesToDiffs :: ProblemDescription -> Set EFix -> [String]
-fixesToDiffs desc@ProbDesc {probModule = Just TypecheckedModule {..}} fixes =
-  map (ppDiffs . snd . applyFixes tm_parsed_module . getFixBinds) fixProgs
+fixesToDiffs desc@ProbDesc {probModuleParsed = Just parsed} fixes =
+  map (ppDiffs . snd . applyFixes parsed . getFixBinds) fixProgs
   where
     ProbDesc {..} = desc
     EProb {..} = progProblem

--- a/src/Endemic/Repair.hs
+++ b/src/Endemic/Repair.hs
@@ -303,7 +303,8 @@ fakeDesc efcs cc prob =
     { progProblem = prob,
       exprFitCands = efcs,
       compConf = cc,
-      probModule = Nothing,
+      probModuleParsed = Nothing,
+      probModuleTypechecked = Nothing,
       initialFixes = Nothing,
       addConf = def {assumeNoLoops = True}
     }
@@ -703,14 +704,15 @@ checkFixes
 describeProblem :: Configuration -> FilePath -> IO (Maybe ProblemDescription)
 describeProblem conf@Conf {compileConfig = ogcc} fp = collectStats $ do
   logStr DEBUG "Describing problem..."
-  (compConf@CompConf {..}, modul, problem) <- moduleToProb ogcc fp Nothing
+  (compConf@CompConf {..}, (parsed_modul, tcd_modul), problem) <- moduleToProb ogcc fp Nothing
   case problem of
     Just ExProb {} -> error "External targets not supported!"
     Nothing -> return Nothing
     Just progProblem@EProb {..} ->
       Just <$> do
-        exprFitCands <- runGhc' compConf $ getExprFitCands $ Right modul
-        let probModule = Just modul
+        exprFitCands <- runGhc' compConf $ getExprFitCands $ Right tcd_modul
+        let probModuleParsed = Just parsed_modul
+            probModuleTypechecked = Just tcd_modul
             initialFixes = Nothing
             addConf = AddConf {assumeNoLoops = True}
             descBase = ProbDesc {..}

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -59,7 +59,7 @@ mkSimpleModuleTest timeout tag toFix repair_target =
     testCase tag $ do
       expected <- readExpected toFix
       setSeedGenSeed tESTSEED
-      (cc', mod, mb_prob) <- moduleToProb def toFix repair_target
+      (cc', (mod, _), mb_prob) <- moduleToProb def toFix repair_target
       case mb_prob of
         Nothing -> [] @?= expected
         Just ExProb {..} -> error "not supported yet!"
@@ -70,7 +70,7 @@ mkSimpleModuleTest timeout tag toFix repair_target =
                 map
                   ( concatMap ppDiff
                       . snd
-                      . applyFixes (tm_parsed_module mod)
+                      . applyFixes mod
                       . getFixBinds
                       . head
                   )

--- a/tests/cases/unnamed.hs
+++ b/tests/cases/unnamed.hs
@@ -4,9 +4,6 @@ prop_is5 = x == 5
 x :: Int
 x = 4
 
-main :: IO ()
-main = putStrLn "hello, world"
-
 ---- EXPECTED ----
 -- diff --git a/tests/cases/unnamed.hs b/tests/cases/unnamed.hs
 -- --- a/tests/cases/unnamed.hs


### PR DESCRIPTION
An attempt to fix #77, but as we can see: since we have to make up an entirely different module to fix (the original one doesn't typecheck!) it introduces a whole host of weird errors. I think we should mark this as `wontfix` for now: we don't fix modules that don't typecheck.