### PR TITLE
[Bugfix] Fix double type declarations. Fixes #78

### DIFF
--- a/src/Endemic/Eval.hs
+++ b/src/Endemic/Eval.hs
@@ -542,7 +542,12 @@ moduleToProb baseCC@CompConf {tempDirBase = baseTempDir} mod_path mb_target = do
 
             prog_sig :: RdrName -> Maybe (RdrName, Sig GhcPs)
             prog_sig t_name = case mapMaybe (getTType t_name) hsmodDecls of
-              (pt : _) -> Just (t_name, pt)
+              (pt : _) ->
+                let sig = case pt of
+                      TypeSig e sgs wt ->
+                        TypeSig e (filter ((t_name ==) . unLoc) sgs) wt
+                      _ -> pt
+                 in Just (t_name, sig)
               _ -> Nothing
 
             targets_n_sigs = mapMaybe prog_sig t_names

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -116,6 +116,7 @@ specialTests =
       mkGenConfTestEx 30_000_000 "Repair Operators" "tests/cases/Operators.hs",
       mkGenConfTestEx 30_000_000 "Repair Data" "tests/cases/Data.hs",
       mkGenConfTestEx 180_000_000 "Repair Multi" "tests/cases/Multi.hs",
+      mkGenConfTestEx 30_000_000 "Repair DoubleDecl" "tests/cases/DoubleDecl.hs",
       mkGenConfTestEx 60_000_000 "All props pass" "tests/cases/AllPropsPass.hs",
       mkGenConfTestEx 60_000_000 "No props" "tests/cases/NoProps.hs",
       mkRepairTest

--- a/tests/cases/DoubleDecl.hs
+++ b/tests/cases/DoubleDecl.hs
@@ -1,0 +1,23 @@
+module DoubleDecl where
+
+x, y :: Int
+x = 32
+y = 17
+
+prop_xIs42 :: Bool
+prop_xIs42 = x == 42
+
+prop_yIs42 :: Bool
+prop_yIs42 = y == 42
+
+---- EXPECTED ----
+-- diff --git a/tests/cases/DoubleDecl.hs b/tests/cases/DoubleDecl.hs
+-- --- a/tests/cases/DoubleDecl.hs
+-- +++ b/tests/cases/DoubleDecl.hs
+-- @@ -4,1 +4,1 @@ x = 32
+-- -x = 32
+-- +x = 42
+-- @@ -5,1 +5,1 @@ y = 17
+-- -y = 17
+-- +y = 42
+---- END EXPECTED ----


### PR DESCRIPTION
A simple matter of filtering out only the referred to rdrName  for each type signature.