### PR TITLE
[Bugfix] Handle ambiguous types

### DIFF
--- a/check-helpers/Check/Helpers.hs
+++ b/check-helpers/Check/Helpers.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Check.Helpers where
+module Check.Helpers
+  ( module Check.Helpers,
+    module QuickCheck,
+  )
+where
 
 import Control.Concurrent
 import Control.Concurrent.STM
@@ -9,6 +13,7 @@ import qualified Data.IntMap as IntMap
 import System.Environment (getArgs, withArgs)
 import System.Exit (ExitCode (ExitSuccess))
 import Test.QuickCheck
+import qualified Test.QuickCheck as QuickCheck (Property)
 import Test.QuickCheck.Random
 import Test.Tasty
 import Test.Tasty (defaultMain, localOption, mkTimeout)

--- a/check-helpers/check-helpers.cabal
+++ b/check-helpers/check-helpers.cabal
@@ -1,7 +1,7 @@
 name: check-helpers
 cabal-version: 1.24
 build-type: Simple
-version: 0.0.4
+version: 0.0.5
 category: Compiler Plugin
 license: MIT
 license-file: LICENSE

--- a/src/Endemic/Types.hs
+++ b/src/Endemic/Types.hs
@@ -104,6 +104,7 @@ type EProgFix = [EExpr]
 data EProblem
   = EProb
       { e_props :: [EProp],
+        e_prop_sigs :: [LSig GhcPs],
         e_ctxt :: EContext,
         e_prog :: EProg,
         e_module :: Maybe ModuleName

--- a/tests/SlowTests.hs
+++ b/tests/SlowTests.hs
@@ -137,7 +137,8 @@ specialTests =
         240_000_000
         "Interpreted Par"
         "tests/cases/LoopBreaker.hs",
-      mkGenConfTestEx 60_000_000 "Wrapped fits" "tests/cases/Wrap.hs"
+      mkGenConfTestEx 60_000_000 "Wrapped fits" "tests/cases/Wrap.hs",
+      mkGenConfTestEx 60_000_000 "Ambiguous fits" "tests/cases/AmbiguousTypeVariables.hs"
     ]
 
 refinementTests :: TestTree

--- a/tests/cases/AmbiguousTypeVariables.hs
+++ b/tests/cases/AmbiguousTypeVariables.hs
@@ -1,0 +1,181 @@
+module AmbiguousTypeVariables where
+
+import Data.List (nub)
+
+isOkay :: [[Maybe Int]] -> Bool
+isOkay sudoku = and [isOkayBlock b | b <- blocks sudoku]
+
+blocks :: [[Maybe Int]] -> [[Maybe Int]]
+blocks = id
+
+isOkayBlock :: [Maybe Int] -> Bool
+isOkayBlock b = length b == length (nub b)
+
+prop_anyBlockBlah :: Int -> Bool
+prop_anyBlockBlah r
+  | r < 0 = True
+  | r == 9 = True
+  | otherwise = not (isOkayBlock [Nothing | _ <- [0 .. r]])
+
+---- EXPECTED ----
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = (negate (length b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = 0 == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (Left (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (head (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (init (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (maximum (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (minimum (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (sequence (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (sequenceA (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length (sequence_ (b)) == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length [] == length (nub b)
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == 0
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (Left ((nub b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (init ((nub b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (maximum ((nub b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (minimum ((nub b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (sequence ((nub b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (sequenceA ((nub b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length Nothing
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length []
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (nub (init (b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (nub (show (b)))
+--
+-- diff --git a/tests/cases/AmbiguousTypeVariables.hs b/tests/cases/AmbiguousTypeVariables.hs
+-- --- a/tests/cases/AmbiguousTypeVariables.hs
+-- +++ b/tests/cases/AmbiguousTypeVariables.hs
+-- @@ -12,1 +12,1 @@ isOkayBlock b = length b == le...
+-- -isOkayBlock b = length b == length (nub b)
+-- +isOkayBlock b = length b == length (nub (tail (b)))
+---- END EXPECTED ----


### PR DESCRIPTION
Sometimes the type annotations are not enough:

```haskell
prop_anyBlockBlah :: Int -> Bool
prop_anyBlockBlah r
  | r < 0 = True
  | r == 9 = True
  | otherwise = not (isOkayBlock [Nothing | _ <- [0 .. r]])
```
here the type of the list isn't actually constrained by the property at all! It's constrained by `isOkayBlock`... but the type of that might vary as we fix! So we introduce `-XPartialTypeSignatures` and give our wrapped properties a type:

```haskell
prop'_anyBlockBlah :: _ -> Int -> Bool
prop'_anyBlockBlah isOkayBlock r
  | r < 0 = True
  | r == 9 = True
  | otherwise = not (isOkayBlock [Nothing | _ <- [0 .. r]])
```

which, in conjucnction with the property being applied to `expr__isOkayBlock` is enough to determine the type!