### PR TITLE
[Feature] Automatically recover from non-compiling fixes

### DIFF
--- a/resources/big_sample_config.json
+++ b/resources/big_sample_config.json
@@ -21,7 +21,8 @@
     "keep_looping_fixes": false,
     "allow_function_fits": true,
     "exclude_targets": [],
-    "extend_defaults": false
+    "extend_defaults": false,
+    "filter_incorrect_fixes": true
   },
   "output_config": {
     "locale": null,

--- a/resources/docker_config.json
+++ b/resources/docker_config.json
@@ -24,7 +24,8 @@
     "keep_looping_fixes": false,
     "allow_function_fits": true,
     "exclude_targets": [],
-    "extend_defaults": false
+    "extend_defaults": false,
+    "filter_incorrect_fixes": true
   },
   "output_config": {
     "locale": null,

--- a/resources/exhaustive_search_config.json
+++ b/resources/exhaustive_search_config.json
@@ -21,7 +21,8 @@
     "keep_looping_fixes": false,
     "allow_function_fits": true,
     "exclude_targets": [],
-    "extend_defaults": false
+    "extend_defaults": false,
+    "filter_incorrect_fixes": true
   },
   "output_config": {
     "locale": null,

--- a/resources/random_search_config.json
+++ b/resources/random_search_config.json
@@ -21,7 +21,8 @@
     "keep_looping_fixes": false,
     "allow_function_fits": true,
     "exclude_targets": [],
-    "extend_defaults": false
+    "extend_defaults": false,
+    "filter_incorrect_fixes": true
   },
   "output_config": {
     "locale": null,

--- a/resources/sample_config.json
+++ b/resources/sample_config.json
@@ -21,7 +21,8 @@
     "keep_looping_fixes": false,
     "allow_function_fits": true,
     "exclude_targets": [],
-    "extend_defaults": false
+    "extend_defaults": false,
+    "filter_incorrect_fixes": true
   },
   "output_config": {
     "locale": null,

--- a/resources/test_config.json
+++ b/resources/test_config.json
@@ -21,7 +21,8 @@
     "keep_looping_fixes": false,
     "allow_function_fits": true,
     "exclude_targets": [],
-    "extend_defaults": false
+    "extend_defaults": false,
+    "filter_incorrect_fixes": true
   },
   "output_config": {
     "locale": null,

--- a/src/Endemic/Configuration/Types.hs
+++ b/src/Endemic/Configuration/Types.hs
@@ -233,7 +233,8 @@ instance Materializeable CompileConfig where
       umKeepLoopingFixes :: Maybe Bool,
       umAllowFunctionFits :: Maybe Bool,
       umExcludeTargets :: Maybe [String],
-      umExtendDefaults :: Maybe Bool
+      umExtendDefaults :: Maybe Bool,
+      umFilterIncorrectFixes :: Maybe Bool
     }
     deriving (Show, Eq, Generic)
     deriving
@@ -242,6 +243,7 @@ instance Materializeable CompileConfig where
 
   conjure =
     UmCompConf
+      Nothing
       Nothing
       Nothing
       Nothing
@@ -281,7 +283,8 @@ instance Materializeable CompileConfig where
         keepLoopingFixes = fromMaybe keepLoopingFixes umKeepLoopingFixes,
         allowFunctionFits = fromMaybe allowFunctionFits umAllowFunctionFits,
         excludeTargets = fromMaybe excludeTargets umExcludeTargets,
-        extendDefaults = fromMaybe extendDefaults umExtendDefaults
+        extendDefaults = fromMaybe extendDefaults umExtendDefaults,
+        filterIncorrectFixes = fromMaybe filterIncorrectFixes umFilterIncorrectFixes
       }
 
 -- | Configuration for the compilation itself
@@ -344,10 +347,14 @@ data CompileConfig = CompConf
     -- | Targets to exclude from repairing. Could be things like examples or
     -- test helpers that we don't want to change.
     excludeTargets :: [String],
-    -- Extend defaults allows us to use GHC's extended defaulting during
+    -- | Extend defaults allows us to use GHC's extended defaulting during
     -- hole-fit generation. Only works if we're not relying too much on
     -- type-defaulting, since the types will not be defaulted during checking.
-    extendDefaults :: Bool
+    extendDefaults :: Bool,
+    -- | With filter incorrect fixes set, we try to recover from incorrect fixes
+    -- by checking the fixes one by one and seeing which ones compile. Without
+    -- this flag, we simply fail on incorrect fixes.
+    filterIncorrectFixes :: Bool
   }
   deriving (Show, Eq, Generic)
   deriving
@@ -374,7 +381,8 @@ instance Default CompileConfig where
         keepLoopingFixes = False,
         allowFunctionFits = True,
         excludeTargets = [],
-        extendDefaults = False
+        extendDefaults = False,
+        filterIncorrectFixes = True
       }
 
 instance Default LogConfig where

--- a/src/Endemic/Eval.hs
+++ b/src/Endemic/Eval.hs
@@ -740,9 +740,6 @@ runGhcWithCleanup CompConf {..} act = do
   when check $ removeDirectoryRecursive tdBase
   return res
 
-debugOutputOnly :: LogAction
-debugOutputOnly _ _ _ _ _ = logOut DEBUG
-
 logOutLogAction :: LogAction
 logOutLogAction dflags _ severity _ _ msgdoc = do
   logStr GHCERR "GHC ERROR:"


### PR DESCRIPTION
We #93  #87 #80 #88 #84 #82 have lot's of bugs where the generated candidates aren't entirely correct. As a safeguard, we can now recover... by finding the fixes that do not compile and removing them from the set of fixes we're checking. This can be toggled on/off with `filterIncorrectFixes`.